### PR TITLE
feat: improve migration of `BeEquivalentTo`

### DIFF
--- a/Source/aweXpect.Migration.Analyzers.CodeFixers/FluentAssertionsCodeFixProvider.cs
+++ b/Source/aweXpect.Migration.Analyzers.CodeFixers/FluentAssertionsCodeFixProvider.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using aweXpect.Migration.Analyzers.Common;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
@@ -44,14 +45,18 @@ public class FluentAssertionsCodeFixProvider() : AssertionCodeFixProvider(Rules.
 
 		ExpressionSyntaxWalker walker = new();
 		walker.Visit(expressionSyntax);
-		string? actual = walker.SubjectText;
+		ExpressionSyntax? actual = walker.Subject;
+		if (actual is null)
+		{
+			return document;
+		}
 
 		string? methodName = memberAccessExpressionSyntax.Name.Identifier.ValueText;
 
 		string? genericArgs = GetGenericArguments(memberAccessExpressionSyntax.Name);
 
-		ExpressionSyntax? newExpression = GetNewExpression(context, memberAccessExpressionSyntax, methodName,
-			actual, expected, genericArgs, expressionSyntax.ArgumentList.Arguments);
+		ExpressionSyntax? newExpression = await GetNewExpression(context,
+			methodName, actual, expected, genericArgs, expressionSyntax.ArgumentList.Arguments);
 
 		if (newExpression != null)
 		{
@@ -63,26 +68,18 @@ public class FluentAssertionsCodeFixProvider() : AssertionCodeFixProvider(Rules.
 	}
 
 #pragma warning disable S3776
-	private static ExpressionSyntax? GetNewExpression(CodeFixContext context,
-		MemberAccessExpressionSyntax memberAccessExpressionSyntax, string method,
-		string? actual, ArgumentSyntax? expected, string genericArgs,
+	private static async Task<ExpressionSyntax?> GetNewExpression(
+		CodeFixContext context,
+		string method,
+		ExpressionSyntax actual,
+		ArgumentSyntax? expected,
+		string genericArgs,
 		SeparatedSyntaxList<ArgumentSyntax> argumentListArguments)
 	{
 		bool isGeneric = !string.IsNullOrEmpty(genericArgs);
 
 		ExpressionSyntax? ParseExpressionWithBecause(string expression, int? becauseIndex = null)
-		{
-			if (becauseIndex.HasValue)
-			{
-				ArgumentSyntax? because = argumentListArguments.ElementAtOrDefault(becauseIndex.Value);
-				if (because != null)
-				{
-					expression += $".Because({because})";
-				}
-			}
-
-			return SyntaxFactory.ParseExpression(expression);
-		}
+			=> ParseExpressionWithBecauseSupport(argumentListArguments, expression, becauseIndex);
 
 		return method switch
 		{
@@ -90,10 +87,8 @@ public class FluentAssertionsCodeFixProvider() : AssertionCodeFixProvider(Rules.
 				$"Expect.That({actual}).IsEqualTo({expected})", 1),
 			"NotBe" => ParseExpressionWithBecause(
 				$"Expect.That({actual}).IsNotEqualTo({expected})", 1),
-			"BeEquivalentTo" => ParseExpressionWithBecause(
-				$"Expect.That({actual}).IsEquivalentTo({expected})", 1),
-			"NotBeEquivalentTo" => ParseExpressionWithBecause(
-				$"Expect.That({actual}).IsNotEquivalentTo({expected})", 1),
+			"BeEquivalentTo" => await BeEquivalentTo(context, argumentListArguments, actual, expected),
+			"NotBeEquivalentTo" => await BeEquivalentTo(context, argumentListArguments, actual, expected, true),
 			"Contain" => ParseExpressionWithBecause(
 				$"Expect.That({actual}).Contains({expected})", 1),
 			"NotContain" => ParseExpressionWithBecause(
@@ -135,7 +130,8 @@ public class FluentAssertionsCodeFixProvider() : AssertionCodeFixProvider(Rules.
 			"BeLessThanOrEqualTo" => ParseExpressionWithBecause(
 				$"Expect.That({actual}).IsLessThanOrEqualTo({expected})", 1),
 			"BeApproximately" => ParseExpressionWithBecause(
-				$"Expect.That({actual}).IsEqualTo({expected}).Within({argumentListArguments.ElementAtOrDefault(1)})", 2),
+				$"Expect.That({actual}).IsEqualTo({expected}).Within({argumentListArguments.ElementAtOrDefault(1)})",
+				2),
 			"BeAfter" => ParseExpressionWithBecause(
 				$"Expect.That({actual}).IsAfter({expected})", 1),
 			"BeOnOrAfter" => ParseExpressionWithBecause(
@@ -193,7 +189,7 @@ public class FluentAssertionsCodeFixProvider() : AssertionCodeFixProvider(Rules.
 				: ParseExpressionWithBecause(
 					$"Expect.That({actual}).IsNotExactly({expected})", 1),
 			"NotThrow" or "NotThrowAsync" => ParseExpressionWithBecause(
-					$"Expect.That({actual}).DoesNotThrow()", 0),
+				$"Expect.That({actual}).DoesNotThrow()", 0),
 			"Throw" or "ThrowAsync" => isGeneric
 				? ParseExpressionWithBecause(
 					$"Expect.That({actual}).Throws<{genericArgs}>()", 0)
@@ -209,6 +205,97 @@ public class FluentAssertionsCodeFixProvider() : AssertionCodeFixProvider(Rules.
 	}
 #pragma warning restore S3776
 
+	private static async Task<ExpressionSyntax?> BeEquivalentTo(CodeFixContext context,
+		SeparatedSyntaxList<ArgumentSyntax> argumentListArguments,
+		ExpressionSyntax actual, ArgumentSyntax? expected, bool negated = false)
+	{
+		SemanticModel? semanticModel = await context.Document.GetSemanticModelAsync();
+		ISymbol? actualSymbol = semanticModel.GetSymbolInfo(actual).Symbol;
+		if (semanticModel is not null && actualSymbol is not null &&
+		    GetType(actualSymbol) is { } actualSymbolType)
+		{
+			if (IsEnumerable(actualSymbolType))
+			{
+				string expressionSuffix = "";
+				int becauseIndex = 1;
+				string? secondArgument = argumentListArguments.ElementAtOrDefault(1)?.ToString() ?? "";
+				if (!secondArgument.StartsWith("\"") || !secondArgument.EndsWith("\""))
+				{
+					if (secondArgument.Contains(".WithoutStrictOrdering()"))
+					{
+						expressionSuffix = ".InAnyOrder()";
+					}
+
+					becauseIndex++;
+				}
+
+				return ParseExpressionWithBecauseSupport(argumentListArguments,
+					$"Expect.That({actual}).{(negated ? "IsNotEqualTo" : "IsEqualTo")}({expected})" + expressionSuffix,
+					becauseIndex);
+			}
+		}
+
+		return ParseExpressionWithBecauseSupport(argumentListArguments,
+			$"Expect.That({actual}).{(negated ? "IsNotEquivalentTo" : "IsEquivalentTo")}({expected})", 1);
+	}
+
+	private static ExpressionSyntax? ParseExpressionWithBecauseSupport(
+		SeparatedSyntaxList<ArgumentSyntax> argumentListArguments, string expression, int? becauseIndex = null)
+	{
+		if (becauseIndex.HasValue)
+		{
+			ArgumentSyntax? because = argumentListArguments.ElementAtOrDefault(becauseIndex.Value);
+			if (because != null)
+			{
+				expression += $".Because({because})";
+			}
+		}
+
+		return SyntaxFactory.ParseExpression(expression);
+	}
+
+	private static ITypeSymbol? GetType(ISymbol symbol)
+	{
+		if (symbol is ITypeSymbol typeSymbol)
+		{
+			return typeSymbol;
+		}
+
+		if (symbol is IPropertySymbol propertySymbol)
+		{
+			return propertySymbol.Type;
+		}
+
+		if (symbol is IFieldSymbol fieldSymbol)
+		{
+			return fieldSymbol.Type;
+		}
+
+		if (symbol is ILocalSymbol localSymbol)
+		{
+			return localSymbol.Type;
+		}
+
+		return null;
+	}
+
+	private static bool IsEnumerable(ITypeSymbol typeSymbol)
+	{
+		if (typeSymbol is IArrayTypeSymbol)
+		{
+			return true;
+		}
+
+		if (typeSymbol is INamedTypeSymbol namedTypeSymbol
+		    && namedTypeSymbol.GloballyQualifiedNonGeneric() is "global::System.Collections.IEnumerable"
+			    or "global::System.Collections.Generic.IEnumerable")
+		{
+			return true;
+		}
+
+		return typeSymbol.AllInterfaces.Any(i => i.GloballyQualified() == "global::System.Collections.IEnumerable");
+	}
+
 	private static string GetGenericArguments(ExpressionSyntax expressionSyntax)
 	{
 		if (expressionSyntax is GenericNameSyntax genericName)
@@ -222,13 +309,13 @@ public class FluentAssertionsCodeFixProvider() : AssertionCodeFixProvider(Rules.
 	private sealed class ExpressionSyntaxWalker : SyntaxWalker
 	{
 		private bool _isShould;
-		public string? SubjectText { get; private set; }
+		public ExpressionSyntax? Subject { get; private set; }
 
 		public override void Visit(SyntaxNode node)
 		{
 			if (_isShould && node is not ParenthesizedExpressionSyntax)
 			{
-				SubjectText = node.ToString();
+				Subject = node as ExpressionSyntax;
 				_isShould = false;
 			}
 

--- a/Tests/aweXpect.Migration.Tests/FluentAssertions/FluentAssertionsCodeFixProviderTestCases.cs
+++ b/Tests/aweXpect.Migration.Tests/FluentAssertions/FluentAssertionsCodeFixProviderTestCases.cs
@@ -23,9 +23,21 @@ public static class FluentAssertionsCodeFixProviderTestCases
 		theoryData.AddWithBecause("object subject = new object();object expected = new object();",
 			"subject.Should().BeEquivalentTo(expected, {0})",
 			"Expect.That(subject).IsEquivalentTo(expected)");
+		theoryData.AddWithBecause("byte[] subject = [];byte[] expected = [];",
+			"subject.Should().BeEquivalentTo(expected, {0})",
+			"Expect.That(subject).IsEqualTo(expected)");
+		theoryData.AddWithBecause("IEnumerable<string> subject = [];string[] expected = [];",
+			"subject.Should().BeEquivalentTo(expected, o => o.WithStrictOrdering(), {0})",
+			"Expect.That(subject).IsEqualTo(expected)");
+		theoryData.AddWithBecause("int[] subject = [];int[] expected = [];",
+			"subject.Should().BeEquivalentTo(expected, o => o.WithoutStrictOrdering(), {0})",
+			"Expect.That(subject).IsEqualTo(expected).InAnyOrder()");
 		theoryData.AddWithBecause("object subject = new object();object unexpected = new object();",
 			"subject.Should().NotBeEquivalentTo(unexpected, {0})",
 			"Expect.That(subject).IsNotEquivalentTo(unexpected)");
+		theoryData.AddWithBecause("int[] subject = [];int[] unexpected = [];",
+			"subject.Should().NotBeEquivalentTo(unexpected, {0})",
+			"Expect.That(subject).IsNotEqualTo(unexpected)");
 		theoryData.AddWithBecause("object subject = new Exception();",
 			"subject.Should().BeAssignableTo<ArgumentException>({0})",
 			"Expect.That(subject).Is<ArgumentException>()");

--- a/Tests/aweXpect.Migration.Tests/FluentAssertions/FluentAssertionsCodeFixProviderTests.cs
+++ b/Tests/aweXpect.Migration.Tests/FluentAssertions/FluentAssertionsCodeFixProviderTests.cs
@@ -16,6 +16,7 @@ public class FluentAssertionsCodeFixProviderTests
 		.VerifyCodeFixAsync(
 			$$"""
 			  using System;
+			  using System.Collections.Generic;
 			  using System.Threading.Tasks;
 			  using aweXpect;
 			  using FluentAssertions;
@@ -34,6 +35,7 @@ public class FluentAssertionsCodeFixProviderTests
 			  """,
 			$$"""
 			  using System;
+			  using System.Collections.Generic;
 			  using System.Threading.Tasks;
 			  using aweXpect;
 			  using FluentAssertions;


### PR DESCRIPTION
When calling `BeEquivalentTo` on a collection, use `IsEqualTo` instead. Also detect the optional second parameter with options (and don't interpret it as because parameter) and when `WithoutStrictOrdering` is specified, use `InAnyOrder()`