### PR TITLE
feat: support null-conditional access

### DIFF
--- a/Source/aweXpect.Migration.Analyzers.CodeFixers/AssertionCodeFixProvider.cs
+++ b/Source/aweXpect.Migration.Analyzers.CodeFixers/AssertionCodeFixProvider.cs
@@ -32,17 +32,16 @@ public abstract class AssertionCodeFixProvider(DiagnosticDescriptor rule) : Code
 
 			SyntaxNode? diagnosticNode = root?.FindNode(diagnosticSpan);
 
-			if (diagnosticNode is not InvocationExpressionSyntax expressionSyntax)
+			if (diagnosticNode is ExpressionSyntax expressionSyntax
+			    and (InvocationExpressionSyntax or ConditionalAccessExpressionSyntax))
 			{
-				return;
+				context.RegisterCodeFix(
+					CodeAction.Create(
+						rule.Title.ToString(),
+						c => ConvertAssertionAsync(context, expressionSyntax, c),
+						rule.Id),
+					diagnostic);
 			}
-
-			context.RegisterCodeFix(
-				CodeAction.Create(
-					rule.Title.ToString(),
-					c => ConvertAssertionAsync(context, expressionSyntax, c),
-					rule.Id),
-				diagnostic);
 		}
 	}
 
@@ -50,5 +49,5 @@ public abstract class AssertionCodeFixProvider(DiagnosticDescriptor rule) : Code
 	///     Converts the assertion.
 	/// </summary>
 	protected abstract Task<Document> ConvertAssertionAsync(CodeFixContext context,
-		InvocationExpressionSyntax expressionSyntax, CancellationToken cancellationToken);
+		ExpressionSyntax expressionSyntax, CancellationToken cancellationToken);
 }

--- a/Source/aweXpect.Migration.Analyzers.CodeFixers/FluentAssertionsCodeFixProvider.cs
+++ b/Source/aweXpect.Migration.Analyzers.CodeFixers/FluentAssertionsCodeFixProvider.cs
@@ -84,8 +84,6 @@ public class FluentAssertionsCodeFixProvider() : AssertionCodeFixProvider(Rules.
 				$"Expect.That({actual}).IsNotEqualTo({expected})", 1),
 			"BeEquivalentTo" => await BeEquivalentTo(context, argumentListArguments, actual, expected),
 			"NotBeEquivalentTo" => await BeEquivalentTo(context, argumentListArguments, actual, expected, true),
-			"AllBeEquivalentTo" => ParseExpressionWithBecause(
-				$"Expect.That({actual}).All().AreEquivalentTo({expected})", 1),
 			"Contain" => ParseExpressionWithBecause(
 				$"Expect.That({actual}).Contains({expected})", 1),
 			"NotContain" => ParseExpressionWithBecause(
@@ -165,16 +163,6 @@ public class FluentAssertionsCodeFixProvider() : AssertionCodeFixProvider(Rules.
 				$"Expect.That({actual}).IsNotSameAs({expected})", 1),
 			"HaveCount" => ParseExpressionWithBecause(
 				$"Expect.That({actual}).HasCount({expected})", 1),
-			"AllBeOfType" => isGeneric
-				? ParseExpressionWithBecause(
-					$"Expect.That({actual}).All().AreExactly<{genericArgs}>()", 0)
-				: ParseExpressionWithBecause(
-					$"Expect.That({actual}).All().AreExactly({expected})", 1),
-			"AllBeAssignableTo" => isGeneric
-				? ParseExpressionWithBecause(
-					$"Expect.That({actual}).All().Are<{genericArgs}>()", 0)
-				: ParseExpressionWithBecause(
-					$"Expect.That({actual}).All().Are({expected})", 1),
 			"BeAssignableTo" => isGeneric
 				? ParseExpressionWithBecause(
 					$"Expect.That({actual}).Is<{genericArgs}>()", 0)

--- a/Source/aweXpect.Migration.Analyzers/FluentAssertionsAnalyzer.cs
+++ b/Source/aweXpect.Migration.Analyzers/FluentAssertionsAnalyzer.cs
@@ -44,9 +44,13 @@ public class FluentAssertionsAnalyzer : DiagnosticAnalyzer
 				syntax = syntax.Parent;
 			}
 
-			context.ReportDiagnostic(
-				Diagnostic.Create(Rules.FluentAssertionsRule, syntax.GetLocation())
-			);
+			// Do not report nested `.Should()` e.g. in `.Should().AllSatisfy(x => x.Should().BeGreaterThan(0));`
+			if (syntax.Parent is not ArgumentSyntax)
+			{
+				context.ReportDiagnostic(
+					Diagnostic.Create(Rules.FluentAssertionsRule, syntax.GetLocation())
+				);
+			}
 		}
 	}
 }

--- a/Tests/aweXpect.Migration.Tests/FluentAssertions/FluentAssertionsAnalyzerTests.cs
+++ b/Tests/aweXpect.Migration.Tests/FluentAssertions/FluentAssertionsAnalyzerTests.cs
@@ -29,30 +29,6 @@ public class FluentAssertionsAnalyzerTests
 			Verifier.Diagnostic(Rules.FluentAssertionsRule)
 				.WithLocation(0)
 		);
-	[Fact]
-	public async Task WhenUsingNullableProperties_ShouldBeFlagged() => await Verifier
-		.VerifyAnalyzerAsync(
-			"""
-			using System;
-			using aweXpect;
-			using FluentAssertions;
-			using Xunit;
-
-			public class MyClass
-			{
-			    [Theory]
-			    [InlineData("bar")]
-			    public void MyTest(string expected)
-			    {
-			        Exception subject = new Exception("foo");
-			        
-			        {|#0:subject?.Message.Should().Be(expected)|};
-			    }
-			}
-			""",
-			Verifier.Diagnostic(Rules.FluentAssertionsRule)
-				.WithLocation(0)
-		);
 
 	[Fact]
 	public async Task WhenUsingAssertTrue_ShouldBeFlagged() => await Verifier
@@ -93,6 +69,31 @@ public class FluentAssertionsAnalyzerTests
 			        int[] subject = [];
 			        
 			        {|#0:subject.Should().AllSatisfy(item => item.Should().BeGreaterThan(0))|};
+			    }
+			}
+			""",
+			Verifier.Diagnostic(Rules.FluentAssertionsRule)
+				.WithLocation(0)
+		);
+
+	[Fact]
+	public async Task WhenUsingNullableProperties_ShouldBeFlagged() => await Verifier
+		.VerifyAnalyzerAsync(
+			"""
+			using System;
+			using aweXpect;
+			using FluentAssertions;
+			using Xunit;
+
+			public class MyClass
+			{
+			    [Theory]
+			    [InlineData("bar")]
+			    public void MyTest(string expected)
+			    {
+			        Exception subject = new Exception("foo");
+			        
+			        {|#0:subject?.Message.Should().Be(expected)|};
 			    }
 			}
 			""",

--- a/Tests/aweXpect.Migration.Tests/FluentAssertions/FluentAssertionsAnalyzerTests.cs
+++ b/Tests/aweXpect.Migration.Tests/FluentAssertions/FluentAssertionsAnalyzerTests.cs
@@ -29,6 +29,30 @@ public class FluentAssertionsAnalyzerTests
 			Verifier.Diagnostic(Rules.FluentAssertionsRule)
 				.WithLocation(0)
 		);
+	[Fact]
+	public async Task WhenUsingNullableProperties_ShouldBeFlagged() => await Verifier
+		.VerifyAnalyzerAsync(
+			"""
+			using System;
+			using aweXpect;
+			using FluentAssertions;
+			using Xunit;
+
+			public class MyClass
+			{
+			    [Theory]
+			    [InlineData("bar")]
+			    public void MyTest(string expected)
+			    {
+			        Exception subject = new Exception("foo");
+			        
+			        {|#0:subject?.Message.Should().Be(expected)|};
+			    }
+			}
+			""",
+			Verifier.Diagnostic(Rules.FluentAssertionsRule)
+				.WithLocation(0)
+		);
 
 	[Fact]
 	public async Task WhenUsingAssertTrue_ShouldBeFlagged() => await Verifier
@@ -46,6 +70,29 @@ public class FluentAssertionsAnalyzerTests
 			        bool subject = true;
 			        
 			        {|#0:subject.Should().BeTrue()|};
+			    }
+			}
+			""",
+			Verifier.Diagnostic(Rules.FluentAssertionsRule)
+				.WithLocation(0)
+		);
+
+	[Fact]
+	public async Task WhenUsingNestedShould_ShouldOnlyBeFlaggedOnce() => await Verifier
+		.VerifyAnalyzerAsync(
+			"""
+			using aweXpect;
+			using FluentAssertions;
+			using Xunit;
+
+			public class MyClass
+			{
+			    [Fact]
+			    public void MyTest()
+			    {
+			        int[] subject = [];
+			        
+			        {|#0:subject.Should().AllSatisfy(item => item.Should().BeGreaterThan(0))|};
 			    }
 			}
 			""",

--- a/Tests/aweXpect.Migration.Tests/FluentAssertions/FluentAssertionsCodeFixProviderTests.cs
+++ b/Tests/aweXpect.Migration.Tests/FluentAssertions/FluentAssertionsCodeFixProviderTests.cs
@@ -93,6 +93,59 @@ public class FluentAssertionsCodeFixProviderTests
 			"""
 		);
 
+	[Fact]
+	public async Task ShouldSupportNullablePropertyAccess() => await Verifier
+		.VerifyCodeFixAsync(
+			"""
+			using System;
+			using aweXpect;
+			using FluentAssertions;
+			using Xunit;
+
+			public class MyTestClass
+			{
+			    [Theory]
+			    [InlineData("bar")]
+			    public void MyTest(string expected)
+			    {
+			        MyClass subject = new();
+			        
+			        [|subject?.Inner?.NewInner()?.Value.Should().Be(expected)|];
+			    }
+			    private class MyClass
+			    {
+			        public MyClass NewInner() => new MyClass();
+			        public MyClass Inner => null;
+			        public string Value => "";
+			    }
+			}
+			""",
+			"""
+			using System;
+			using aweXpect;
+			using FluentAssertions;
+			using Xunit;
+
+			public class MyTestClass
+			{
+			    [Theory]
+			    [InlineData("bar")]
+			    public void MyTest(string expected)
+			    {
+			        MyClass subject = new();
+			        
+			        Expect.That(subject?.Inner?.NewInner()?.Value).IsEqualTo(expected);
+			    }
+			    private class MyClass
+			    {
+			        public MyClass NewInner() => new MyClass();
+			        public MyClass Inner => null;
+			        public string Value => "";
+			    }
+			}
+			"""
+		);
+
 	public static TheoryData<string, string, string, bool> GetTestCases()
 		=> new TheoryData<string, string, string, bool>()
 			.AddBasicTestCases()


### PR DESCRIPTION
When accessing properties or members conditionally it should still be migrated correctly, e.g.
```csharp
subject?.Inner?.NewInner()?.Value.Should().Be(expected);
// should be migrated to
Expect.That(subject?.Inner?.NewInner()?.Value).IsEqualTo(expected);
```