### PR TITLE
feat: support lambda expressions with `Synchronously.Verify`

### DIFF
--- a/Source/aweXpect.Migration.Analyzers.CodeFixers/AssertionCodeFixProvider.cs
+++ b/Source/aweXpect.Migration.Analyzers.CodeFixers/AssertionCodeFixProvider.cs
@@ -33,7 +33,7 @@ public abstract class AssertionCodeFixProvider(DiagnosticDescriptor rule) : Code
 			SyntaxNode? diagnosticNode = root?.FindNode(diagnosticSpan);
 
 			if (diagnosticNode is ExpressionSyntax expressionSyntax
-			    and (InvocationExpressionSyntax or ConditionalAccessExpressionSyntax))
+			    and (InvocationExpressionSyntax or ConditionalAccessExpressionSyntax or LambdaExpressionSyntax))
 			{
 				context.RegisterCodeFix(
 					CodeAction.Create(

--- a/Tests/aweXpect.Migration.Tests/FluentAssertions/FluentAssertionsAnalyzerTests.cs
+++ b/Tests/aweXpect.Migration.Tests/FluentAssertions/FluentAssertionsAnalyzerTests.cs
@@ -7,6 +7,31 @@ namespace aweXpect.Migration.Tests.FluentAssertions;
 public class FluentAssertionsAnalyzerTests
 {
 	[Fact]
+	public async Task ShouldSupportActions() => await Verifier
+		.VerifyAnalyzerAsync(
+			"""
+			using System;
+			using System.Threading.Tasks;
+			using aweXpect;
+			using FluentAssertions;
+			using Xunit;
+
+			public class MyTestClass
+			{
+			    [Fact]
+			    public void MyTest()
+			    {
+			        Action action = {|#0:() => true.Should().BeTrue()|};
+			        
+			        action();
+			    }
+			}
+			""",
+			Verifier.Diagnostic(Rules.FluentAssertionsRule)
+				.WithLocation(0)
+		);
+
+	[Fact]
 	public async Task WhenUsingAssertEqual_ShouldBeFlagged() => await Verifier
 		.VerifyAnalyzerAsync(
 			"""

--- a/Tests/aweXpect.Migration.Tests/FluentAssertions/FluentAssertionsCodeFixProviderTests.cs
+++ b/Tests/aweXpect.Migration.Tests/FluentAssertions/FluentAssertionsCodeFixProviderTests.cs
@@ -7,52 +7,60 @@ namespace aweXpect.Migration.Tests.FluentAssertions;
 public class FluentAssertionsCodeFixProviderTests
 {
 	[Theory]
-	[MemberData(nameof(GetTestCases))]
-	public async Task ShouldApplyCodeFixForSynchronousTestCases(
+	[MemberData(nameof(TestCases.Basic), MemberType = typeof(TestCases))]
+	public async Task ShouldApplyCodeFixForBasicTestCases(
 		string fluentAssertions,
 		string aweXpect,
 		string arrange,
-		bool isAsync) => await Verifier
-		.VerifyCodeFixAsync(
-			$$"""
-			  using System;
-			  using System.Collections.Generic;
-			  using System.Threading.Tasks;
-			  using aweXpect;
-			  using FluentAssertions;
-			  using Xunit;
+		bool isAsync) => await VerifyTestCase(fluentAssertions, aweXpect, arrange, isAsync);
 
-			  public class MyClass
-			  {
-			      [Fact]
-			      public {{(isAsync ? "async Task" : "void")}} MyTest()
-			      {
-			          {{arrange}}
-			          
-			          {{(isAsync ? "await " : "")}}[|{{fluentAssertions}}|];
-			      }
-			  }
-			  """,
-			$$"""
-			  using System;
-			  using System.Collections.Generic;
-			  using System.Threading.Tasks;
-			  using aweXpect;
-			  using FluentAssertions;
-			  using Xunit;
+	[Theory]
+	[MemberData(nameof(TestCases.Boolean), MemberType = typeof(TestCases))]
+	public async Task ShouldApplyCodeFixForBooleanTestCases(
+		string fluentAssertions,
+		string aweXpect,
+		string arrange,
+		bool isAsync) => await VerifyTestCase(fluentAssertions, aweXpect, arrange, isAsync);
 
-			  public class MyClass
-			  {
-			      [Fact]
-			      public {{(isAsync ? "async Task" : "void")}} MyTest()
-			      {
-			          {{arrange}}
-			          
-			          {{(isAsync ? "await " : "")}}{{aweXpect}};
-			      }
-			  }
-			  """
-		);
+	[Theory]
+	[MemberData(nameof(TestCases.Chronology), MemberType = typeof(TestCases))]
+	public async Task ShouldApplyCodeFixForChronologyTestCases(
+		string fluentAssertions,
+		string aweXpect,
+		string arrange,
+		bool isAsync) => await VerifyTestCase(fluentAssertions, aweXpect, arrange, isAsync);
+
+	[Theory]
+	[MemberData(nameof(TestCases.Collection), MemberType = typeof(TestCases))]
+	public async Task ShouldApplyCodeFixForCollectionTestCases(
+		string fluentAssertions,
+		string aweXpect,
+		string arrange,
+		bool isAsync) => await VerifyTestCase(fluentAssertions, aweXpect, arrange, isAsync);
+
+	[Theory]
+	[MemberData(nameof(TestCases.Exceptions), MemberType = typeof(TestCases))]
+	public async Task ShouldApplyCodeFixForExceptionsTestCases(
+		string fluentAssertions,
+		string aweXpect,
+		string arrange,
+		bool isAsync) => await VerifyTestCase(fluentAssertions, aweXpect, arrange, isAsync);
+
+	[Theory]
+	[MemberData(nameof(TestCases.Numbers), MemberType = typeof(TestCases))]
+	public async Task ShouldApplyCodeFixForNumbersTestCases(
+		string fluentAssertions,
+		string aweXpect,
+		string arrange,
+		bool isAsync) => await VerifyTestCase(fluentAssertions, aweXpect, arrange, isAsync);
+
+	[Theory]
+	[MemberData(nameof(TestCases.Strings), MemberType = typeof(TestCases))]
+	public async Task ShouldApplyCodeFixForStringsTestCases(
+		string fluentAssertions,
+		string aweXpect,
+		string arrange,
+		bool isAsync) => await VerifyTestCase(fluentAssertions, aweXpect, arrange, isAsync);
 
 	[Fact]
 	public async Task ShouldApplyCodeFixInTheory() => await Verifier
@@ -92,6 +100,48 @@ public class FluentAssertionsCodeFixProviderTests
 			}
 			"""
 		);
+
+	[Fact]
+	public async Task ShouldSupportActions() => await Verifier
+		.VerifyCodeFixAsync(
+			"""
+			using System;
+			using System.Threading.Tasks;
+			using aweXpect;
+			using FluentAssertions;
+			using Xunit;
+
+			public class MyTestClass
+			{
+			    [Fact]
+			    public void MyTest()
+			    {
+			        Action action = [|() => true.Should().BeTrue()|];
+			        
+			        action();
+			    }
+			}
+			""",
+			"""
+			using System;
+			using System.Threading.Tasks;
+			using aweXpect;
+			using FluentAssertions;
+			using Xunit;
+
+			public class MyTestClass
+			{
+			    [Fact]
+			    public void MyTest()
+			    {
+			        Action action = () => aweXpect.Synchronous.Synchronously.Verify(Expect.That(true).IsTrue());
+			        
+			        action();
+			    }
+			}
+			"""
+		);
+
 
 	[Fact]
 	public async Task ShouldSupportNullablePropertyAccess() => await Verifier
@@ -146,13 +196,49 @@ public class FluentAssertionsCodeFixProviderTests
 			"""
 		);
 
-	public static TheoryData<string, string, string, bool> GetTestCases()
-		=> new TheoryData<string, string, string, bool>()
-			.AddBasicTestCases()
-			.AddBooleanTestCases()
-			.AddChronologyTestCases()
-			.AddCollectionTestCases()
-			.AddExceptionsTestCases()
-			.AddNumberTestCases()
-			.AddStringTestCases();
+	private static async Task VerifyTestCase(
+		string fluentAssertions,
+		string aweXpect,
+		string arrange,
+		bool isAsync) => await Verifier
+		.VerifyCodeFixAsync(
+			$$"""
+			  using System;
+			  using System.Collections.Generic;
+			  using System.Threading.Tasks;
+			  using aweXpect;
+			  using FluentAssertions;
+			  using Xunit;
+
+			  public class MyClass
+			  {
+			      [Fact]
+			      public {{(isAsync ? "async Task" : "void")}} MyTest()
+			      {
+			          {{arrange}}
+			          
+			          {{(isAsync ? "await " : "")}}[|{{fluentAssertions}}|];
+			      }
+			  }
+			  """,
+			$$"""
+			  using System;
+			  using System.Collections.Generic;
+			  using System.Threading.Tasks;
+			  using aweXpect;
+			  using FluentAssertions;
+			  using Xunit;
+
+			  public class MyClass
+			  {
+			      [Fact]
+			      public {{(isAsync ? "async Task" : "void")}} MyTest()
+			      {
+			          {{arrange}}
+			          
+			          {{(isAsync ? "await " : "")}}{{aweXpect}};
+			      }
+			  }
+			  """
+		);
 }

--- a/Tests/aweXpect.Migration.Tests/FluentAssertions/TestCases.cs
+++ b/Tests/aweXpect.Migration.Tests/FluentAssertions/TestCases.cs
@@ -1,13 +1,13 @@
 ﻿namespace aweXpect.Migration.Tests.FluentAssertions;
 
-public static class FluentAssertionsCodeFixProviderTestCases
+public static class TestCases
 {
 	/// <summary>
 	///     <see href="https://fluentassertions.com/basicassertions/" />
 	/// </summary>
-	internal static TheoryData<string, string, string, bool> AddBasicTestCases(
-		this TheoryData<string, string, string, bool> theoryData)
+	public static TheoryData<string, string, string, bool> Basic()
 	{
+		TheoryData<string, string, string, bool> theoryData = new();
 		theoryData.AddWithBecause("object subject = new object();",
 			"subject.Should().BeNull()",
 			"Expect.That(subject).IsNull()");
@@ -68,9 +68,9 @@ public static class FluentAssertionsCodeFixProviderTestCases
 	/// <summary>
 	///     <see href="https://fluentassertions.com/booleans/" />
 	/// </summary>
-	internal static TheoryData<string, string, string, bool> AddBooleanTestCases(
-		this TheoryData<string, string, string, bool> theoryData)
+	public static TheoryData<string, string, string, bool> Boolean()
 	{
+		TheoryData<string, string, string, bool> theoryData = new();
 		theoryData.AddWithBecause("bool subject = false;",
 			"subject.Should().BeTrue({0})",
 			"Expect.That(subject).IsTrue()");
@@ -92,9 +92,9 @@ public static class FluentAssertionsCodeFixProviderTestCases
 	/// <summary>
 	///     <see href="https://fluentassertions.com/collections/" />
 	/// </summary>
-	internal static TheoryData<string, string, string, bool> AddCollectionTestCases(
-		this TheoryData<string, string, string, bool> theoryData)
+	public static TheoryData<string, string, string, bool> Collection()
 	{
+		TheoryData<string, string, string, bool> theoryData = new();
 		theoryData.AddWithBecause("int[] subject = [1, 2,];",
 			"subject.Should().HaveCount(1, {0})",
 			"Expect.That(subject).HasCount(1)");
@@ -104,9 +104,9 @@ public static class FluentAssertionsCodeFixProviderTestCases
 	/// <summary>
 	///     <see href="https://fluentassertions.com/exceptions/" />
 	/// </summary>
-	internal static TheoryData<string, string, string, bool> AddExceptionsTestCases(
-		this TheoryData<string, string, string, bool> theoryData)
+	public static TheoryData<string, string, string, bool> Exceptions()
 	{
+		TheoryData<string, string, string, bool> theoryData = new();
 		theoryData.AddWithBecause("Action callback = () => {};",
 			"callback.Should().NotThrow({0})",
 			"Expect.That(callback).DoesNotThrow()");
@@ -134,9 +134,9 @@ public static class FluentAssertionsCodeFixProviderTestCases
 	/// <summary>
 	///     <see href="https://fluentassertions.com/numerictypes/" />
 	/// </summary>
-	internal static TheoryData<string, string, string, bool> AddNumberTestCases(
-		this TheoryData<string, string, string, bool> theoryData)
+	public static TheoryData<string, string, string, bool> Numbers()
 	{
+		TheoryData<string, string, string, bool> theoryData = new();
 		theoryData.AddWithBecause("int subject = 1;",
 			"subject.Should().BePositive({0})",
 			"Expect.That(subject).IsPositive()");
@@ -170,9 +170,9 @@ public static class FluentAssertionsCodeFixProviderTestCases
 	/// <summary>
 	///     <see href="https://fluentassertions.com/datetimespans/" />
 	/// </summary>
-	internal static TheoryData<string, string, string, bool> AddChronologyTestCases(
-		this TheoryData<string, string, string, bool> theoryData)
+	public static TheoryData<string, string, string, bool> Chronology()
 	{
+		TheoryData<string, string, string, bool> theoryData = new();
 		theoryData.AddWithBecause("DateTime subject = DateTime.Now;DateTime expected = DateTime.Now;",
 			"subject.Should().BeAfter(expected, {0})",
 			"Expect.That(subject).IsAfter(expected)");
@@ -203,9 +203,9 @@ public static class FluentAssertionsCodeFixProviderTestCases
 	/// <summary>
 	///     <see href="https://fluentassertions.com/strings/" />
 	/// </summary>
-	internal static TheoryData<string, string, string, bool> AddStringTestCases(
-		this TheoryData<string, string, string, bool> theoryData)
+	public static TheoryData<string, string, string, bool> Strings()
 	{
+		TheoryData<string, string, string, bool> theoryData = new();
 		theoryData.AddWithBecause("string subject = \"foo\";",
 			"subject.Should().BeNull({0})",
 			"Expect.That(subject).IsNull()");


### PR DESCRIPTION
Within an action lambda, use `Synchronously.Verify` to migrate fluentassertions to aweXpect.