### PR TITLE
feat: add migrations for Enums

### DIFF
--- a/Source/aweXpect.Migration.Analyzers.CodeFixers/FluentAssertionsCodeFixProvider.cs
+++ b/Source/aweXpect.Migration.Analyzers.CodeFixers/FluentAssertionsCodeFixProvider.cs
@@ -163,6 +163,24 @@ public class FluentAssertionsCodeFixProvider() : AssertionCodeFixProvider(Rules.
 				$"Expect.That({actual}).IsNotFalse()", 0),
 			"Imply" => ParseExpressionWithBecause(
 				$"Expect.That({actual}).Implies({expected})", 1),
+			"BeDefined" => ParseExpressionWithBecause(
+				$"Expect.That({actual}).IsDefined()", 0),
+			"NotBeDefined" => ParseExpressionWithBecause(
+				$"Expect.That({actual}).IsNotDefined()", 0),
+			"HaveValue" => expected is null || expected.Expression.ToString().Contains('\"')
+				? ParseExpressionWithBecause(
+					$"Expect.That({actual}).IsNotNull()", 0)
+				: ParseExpressionWithBecause(
+					$"Expect.That({actual}).HasValue({expected})", 1),
+			"NotHaveValue" => expected is null || expected.Expression.ToString().Contains('\"')
+				? ParseExpressionWithBecause(
+					$"Expect.That({actual}).IsNull()", 0)
+				: ParseExpressionWithBecause(
+					$"Expect.That({actual}).DoesNotHaveValue({expected})", 1),
+			"HaveFlag" => ParseExpressionWithBecause(
+				$"Expect.That({actual}).HasFlag({expected})", 1),
+			"NotHaveFlag" => ParseExpressionWithBecause(
+				$"Expect.That({actual}).DoesNotHaveFlag({expected})", 1),
 			"BeSameAs" => ParseExpressionWithBecause(
 				$"Expect.That({actual}).IsSameAs({expected})", 1),
 			"NotBeSameAs" => ParseExpressionWithBecause(
@@ -331,8 +349,6 @@ public class FluentAssertionsCodeFixProvider() : AssertionCodeFixProvider(Rules.
 				return [];
 			}
 		}
-
-		public List<MemberAccessExpressionSyntax> Methods { get; } = new();
 
 		public override void Visit(SyntaxNode node)
 		{

--- a/Tests/aweXpect.Migration.Tests/FluentAssertions/FluentAssertionsCodeFixProviderTests.cs
+++ b/Tests/aweXpect.Migration.Tests/FluentAssertions/FluentAssertionsCodeFixProviderTests.cs
@@ -39,6 +39,14 @@ public class FluentAssertionsCodeFixProviderTests
 		bool isAsync) => await VerifyTestCase(fluentAssertions, aweXpect, arrange, isAsync);
 
 	[Theory]
+	[MemberData(nameof(TestCases.Enums), MemberType = typeof(TestCases))]
+	public async Task ShouldApplyCodeFixForEnumsTestCases(
+		string fluentAssertions,
+		string aweXpect,
+		string arrange,
+		bool isAsync) => await VerifyTestCase(fluentAssertions, aweXpect, arrange, isAsync);
+
+	[Theory]
 	[MemberData(nameof(TestCases.Exceptions), MemberType = typeof(TestCases))]
 	public async Task ShouldApplyCodeFixForExceptionsTestCases(
 		string fluentAssertions,

--- a/Tests/aweXpect.Migration.Tests/FluentAssertions/TestCases.cs
+++ b/Tests/aweXpect.Migration.Tests/FluentAssertions/TestCases.cs
@@ -102,6 +102,39 @@ public static class TestCases
 	}
 
 	/// <summary>
+	///     <see href="https://fluentassertions.com/collections/" />
+	/// </summary>
+	public static TheoryData<string, string, string, bool> Enums()
+	{
+		TheoryData<string, string, string, bool> theoryData = new();
+		theoryData.AddWithBecause("DayOfWeek subject = DayOfWeek.Monday;",
+			"subject.Should().BeDefined({0})",
+			"Expect.That(subject).IsDefined()");
+		theoryData.AddWithBecause("DayOfWeek subject = DayOfWeek.Monday;",
+			"subject.Should().NotBeDefined({0})",
+			"Expect.That(subject).IsNotDefined()");
+		theoryData.AddWithBecause("DayOfWeek? subject = DayOfWeek.Monday;",
+			"subject.Should().HaveValue({0})",
+			"Expect.That(subject).IsNotNull()");
+		theoryData.AddWithBecause("DayOfWeek? subject = DayOfWeek.Monday;",
+			"subject.Should().HaveValue(1, {0})",
+			"Expect.That(subject).HasValue(1)");
+		theoryData.AddWithBecause("DayOfWeek? subject = DayOfWeek.Monday;",
+			"subject.Should().NotHaveValue({0})",
+			"Expect.That(subject).IsNull()");
+		theoryData.AddWithBecause("DayOfWeek? subject = DayOfWeek.Monday;",
+			"subject.Should().NotHaveValue(2, {0})",
+			"Expect.That(subject).DoesNotHaveValue(2)");
+		theoryData.AddWithBecause("DayOfWeek subject = DayOfWeek.Monday;",
+			"subject.Should().HaveFlag(DayOfWeek.Tuesday, {0})",
+			"Expect.That(subject).HasFlag(DayOfWeek.Tuesday)");
+		theoryData.AddWithBecause("DayOfWeek subject = DayOfWeek.Monday;",
+			"subject.Should().NotHaveFlag(DayOfWeek.Tuesday, {0})",
+			"Expect.That(subject).DoesNotHaveFlag(DayOfWeek.Tuesday)");
+		return theoryData;
+	}
+
+	/// <summary>
 	///     <see href="https://fluentassertions.com/exceptions/" />
 	/// </summary>
 	public static TheoryData<string, string, string, bool> Exceptions()


### PR DESCRIPTION
- `{Not}BeDefined` -> `Is{Not}Defined`
- `{Not}HaveValue` -> `HasValue`/`DoesNotHaveValue` or `IsNull`/`IsNotNull` when no value is provided
- `{Not}HaveFlag` -> `HasFlag`/`DoesNotHaveFlag`