### PR TITLE
feat: improve xunit `Assert.Equal` with tolerance migration

### DIFF
--- a/Source/aweXpect.Migration.Analyzers.CodeFixers/XunitAssertionCodeFixProvider.cs
+++ b/Source/aweXpect.Migration.Analyzers.CodeFixers/XunitAssertionCodeFixProvider.cs
@@ -1,8 +1,9 @@
-﻿using System.Composition;
+﻿using System;
+using System.Composition;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using aweXpect.Migration.Analyzers.Common;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
@@ -136,105 +137,56 @@ public class XunitAssertionCodeFixProvider() : AssertionCodeFixProvider(Rules.Xu
 	}
 #pragma warning restore S3776
 
-	private static async Task<ExpressionSyntax> IsNotEqualTo(CodeFixContext context,
+	private static Task<ExpressionSyntax> IsNotEqualTo(CodeFixContext context,
 		SeparatedSyntaxList<ArgumentSyntax> argumentListArguments,
 		ArgumentSyntax? actual, ArgumentSyntax? expected)
 	{
-		if (argumentListArguments.Count >= 3 && argumentListArguments[2].Expression is LiteralExpressionSyntax
-			                                     literalExpressionSyntax
-		                                     && decimal.TryParse(literalExpressionSyntax.Token.ValueText, out _))
+		if (argumentListArguments.Count >= 3
+		    && argumentListArguments[2].Expression is LiteralExpressionSyntax literalExpressionSyntax)
 		{
-			return SyntaxFactory.ParseExpression(
-				$"Expect.That({actual}).IsNotEqualTo({expected}).Within({literalExpressionSyntax})");
+			if (decimal.TryParse(literalExpressionSyntax.Token.ValueText, NumberStyles.Any,
+				    CultureInfo.InvariantCulture, out _)
+			    || TimeSpan.TryParse(literalExpressionSyntax.Token.ValueText, out _))
+			{
+				return Task.FromResult(SyntaxFactory.ParseExpression(
+					$"Expect.That({actual}).IsNotEqualTo({expected}).Within({literalExpressionSyntax})"));
+			}
 		}
 
-		SemanticModel? semanticModel = await context.Document.GetSemanticModelAsync();
-
-		ISymbol? actualSymbol = semanticModel.GetSymbolInfo(actual!.Expression).Symbol;
-		ISymbol? expectedSymbol = semanticModel.GetSymbolInfo(expected!.Expression).Symbol;
-
-		if (actualSymbol is not null && expectedSymbol is not null
-		                             && GetType(actualSymbol) is { } actualSymbolType
-		                             && GetType(expectedSymbol) is { } expectedSymbolType
-		                             && IsEnumerable(actualSymbolType)
-		                             && IsEnumerable(expectedSymbolType))
-		{
-			return SyntaxFactory.ParseExpression($"Expect.That({actual}).IsNotEquivalentTo({expected})");
-		}
-
-		return SyntaxFactory.ParseExpression($"Expect.That({actual}).IsNotEqualTo({expected})");
+		return Task.FromResult(SyntaxFactory.ParseExpression($"Expect.That({actual}).IsNotEqualTo({expected})"));
 	}
 
 	private static async Task<ExpressionSyntax> IsEqualTo(CodeFixContext context,
 		SeparatedSyntaxList<ArgumentSyntax> argumentListArguments,
 		ArgumentSyntax? actual, ArgumentSyntax? expected)
 	{
-		if (argumentListArguments.Count >= 3 && argumentListArguments[2].Expression is LiteralExpressionSyntax
-			                                     literalExpressionSyntax
-		                                     && decimal.TryParse(literalExpressionSyntax.Token.ValueText, out _))
+		if (argumentListArguments.Count >= 3)
 		{
-			return SyntaxFactory.ParseExpression(
-				$"Expect.That({actual}).IsEqualTo({expected}).Within({literalExpressionSyntax})");
-		}
+			var thirdArgument = argumentListArguments[2].Expression;
+			if (thirdArgument is LiteralExpressionSyntax literalExpressionSyntax &&
+			    decimal.TryParse(literalExpressionSyntax.Token.ValueText, NumberStyles.Any,
+				    CultureInfo.InvariantCulture, out _))
+			{
+				return SyntaxFactory.ParseExpression(
+					$"Expect.That({actual}).IsEqualTo({expected}).Within({literalExpressionSyntax})");
+			}
+			SemanticModel? semanticModel = await context.Document.GetSemanticModelAsync();
 
-		SemanticModel? semanticModel = await context.Document.GetSemanticModelAsync();
+			if (semanticModel != null)
+			{
+				ISymbol? symbol = semanticModel.GetSymbolInfo(thirdArgument).Symbol;
 
-		ISymbol? actualSymbol = semanticModel.GetSymbolInfo(actual!.Expression).Symbol;
-		ISymbol? expectedSymbol = semanticModel.GetSymbolInfo(expected!.Expression).Symbol;
-
-		if (actualSymbol is not null && expectedSymbol is not null
-		                             && GetType(actualSymbol) is { } actualSymbolType
-		                             && GetType(expectedSymbol) is { } expectedSymbolType
-		                             && IsEnumerable(actualSymbolType)
-		                             && IsEnumerable(expectedSymbolType))
-		{
-			return SyntaxFactory.ParseExpression($"Expect.That({actual}).IsEquivalentTo({expected})");
+				if (symbol is IMethodSymbol methodSymbol && methodSymbol.ReturnType.Name == "TimeSpan")
+				{
+					return SyntaxFactory.ParseExpression(
+						$"Expect.That({actual}).IsEqualTo({expected}).Within({thirdArgument})");
+				}
+			}
 		}
 
 		return SyntaxFactory.ParseExpression($"Expect.That({actual}).IsEqualTo({expected})");
 	}
 
-	private static ITypeSymbol? GetType(ISymbol symbol)
-	{
-		if (symbol is ITypeSymbol typeSymbol)
-		{
-			return typeSymbol;
-		}
-
-		if (symbol is IPropertySymbol propertySymbol)
-		{
-			return propertySymbol.Type;
-		}
-
-		if (symbol is IFieldSymbol fieldSymbol)
-		{
-			return fieldSymbol.Type;
-		}
-
-		if (symbol is ILocalSymbol localSymbol)
-		{
-			return localSymbol.Type;
-		}
-
-		return null;
-	}
-
-	private static bool IsEnumerable(ITypeSymbol typeSymbol)
-	{
-		if (typeSymbol is IArrayTypeSymbol)
-		{
-			return true;
-		}
-
-		if (typeSymbol is INamedTypeSymbol namedTypeSymbol
-		    && namedTypeSymbol.GloballyQualifiedNonGeneric() is "global::System.Collections.IEnumerable"
-			    or "global::System.Collections.Generic.IEnumerable")
-		{
-			return true;
-		}
-
-		return typeSymbol.AllInterfaces.Any(i => i.GloballyQualified() == "global::System.Collections.IEnumerable");
-	}
 
 	private static async Task<ExpressionSyntax> Contains(CodeFixContext context,
 		MemberAccessExpressionSyntax memberAccessExpressionSyntax, ArgumentSyntax? actual, ArgumentSyntax? expected)

--- a/Tests/aweXpect.Migration.Tests/Xunit/TestCases.cs
+++ b/Tests/aweXpect.Migration.Tests/Xunit/TestCases.cs
@@ -1,0 +1,185 @@
+﻿namespace aweXpect.Migration.Tests.Xunit;
+
+public static class TestCases
+{
+	/// <summary>
+	///     <see href="https://github.com/xunit/assert.xunit/tree/main" />
+	/// </summary>
+	public static TheoryData<string, string, string, bool> Basic()
+	{
+		TheoryData<string, string, string, bool> theoryData = new();
+		theoryData.AddTestCase("",
+			"Assert.Fail(\"foo\")",
+			"Fail.Test(\"foo\")");
+		theoryData.AddTestCase("",
+			"Assert.Skip(\"foo\")",
+			"Skip.Test(\"foo\")");
+		theoryData.AddTestCase("",
+			"Assert.Null(new object())",
+			"Expect.That(new object()).IsNull()");
+		theoryData.AddTestCase("",
+			"Assert.NotNull(new object())",
+			"Expect.That(new object()).IsNotNull()");
+		theoryData.AddTestCase("",
+			"Assert.Same(new ArgumentException(), new NullReferenceException())",
+			"Expect.That(new NullReferenceException()).IsSameAs(new ArgumentException())");
+		theoryData.AddTestCase("",
+			"Assert.NotSame(new ArgumentException(), new NullReferenceException())",
+			"Expect.That(new NullReferenceException()).IsNotSameAs(new ArgumentException())");
+		return theoryData;
+	}
+
+	/// <summary>
+	///     <see href="https://github.com/xunit/assert.xunit/blob/main/BooleanAsserts.cs" />
+	/// </summary>
+	public static TheoryData<string, string, string, bool> Boolean()
+	{
+		TheoryData<string, string, string, bool> theoryData = new();
+		theoryData.AddTestCase("bool subject = false;",
+			"Assert.True(subject)",
+			"Expect.That(subject).IsTrue()");
+		theoryData.AddTestCase("bool subject = false;",
+			"Assert.False(subject)",
+			"Expect.That(subject).IsFalse()");
+		theoryData.AddTestCase("bool subject = false;",
+			"Assert.True(subject, \"foo\")",
+			"Expect.That(subject).IsTrue().Because(\"foo\")");
+		theoryData.AddTestCase("bool subject = false;",
+			"Assert.False(subject, \"foo\")",
+			"Expect.That(subject).IsFalse().Because(\"foo\")");
+		return theoryData;
+	}
+
+	/// <summary>
+	///     <see href="https://github.com/xunit/assert.xunit/blob/main/CollectionAsserts.cs" />
+	/// </summary>
+	public static TheoryData<string, string, string, bool> Collections()
+	{
+		TheoryData<string, string, string, bool> theoryData = new();
+		theoryData.AddTestCase("",
+			"Assert.Distinct([1, 2,])",
+			"Expect.That([1, 2,]).AreAllUnique()");
+		return theoryData;
+	}
+
+	/// <summary>
+	///     <see href="https://github.com/xunit/assert.xunit/blob/main/EqualityAsserts.cs" />
+	/// </summary>
+	public static TheoryData<string, string, string, bool> Equality()
+	{
+		TheoryData<string, string, string, bool> theoryData = new();
+		theoryData.AddTestCase("",
+			"Assert.Equal(1, 2)",
+			"Expect.That(2).IsEqualTo(1)");
+		theoryData.AddTestCase("",
+			"Assert.Equal(1.0, 1.1, 0.1)",
+			"Expect.That(1.1).IsEqualTo(1.0).Within(0.1)");
+		theoryData.AddTestCase("",
+			"Assert.Equal(DateTime.Now, DateTime.Today, TimeSpan.FromSeconds(1))",
+			"Expect.That(DateTime.Today).IsEqualTo(DateTime.Now).Within(TimeSpan.FromSeconds(1))");
+		theoryData.AddTestCase("",
+			"Assert.NotEqual(1, 2)",
+			"Expect.That(2).IsNotEqualTo(1)");
+		theoryData.AddTestCase("",
+			"Assert.NotEqual(1.0, 1.1, 0.1)",
+			"Expect.That(1.1).IsNotEqualTo(1.0).Within(0.1)");
+		return theoryData;
+	}
+
+	/// <summary>
+	///     <see href="https://github.com/xunit/assert.xunit/blob/main/ExceptionAsserts.cs" />
+	/// </summary>
+	public static TheoryData<string, string, string, bool> Exceptions()
+	{
+		TheoryData<string, string, string, bool> theoryData = new();
+		theoryData.AddTestCase("Action callback = () => {};",
+			"Assert.ThrowsAny<ArgumentException>(callback)",
+			"Expect.That(callback).Throws<ArgumentException>()");
+		theoryData.AddTestCase("Func<Task> callback = () => Task.CompletedTask;",
+			"Assert.ThrowsAnyAsync<ArgumentException>(callback)",
+			"Expect.That(callback).Throws<ArgumentException>()");
+		theoryData.AddTestCase("Action callback = () => {};",
+			"Assert.Throws<ArgumentException>(callback)",
+			"Expect.That(callback).ThrowsExactly<ArgumentException>()");
+		theoryData.AddTestCase("Func<Task> callback = () => Task.CompletedTask;",
+			"Assert.ThrowsAsync<ArgumentException>(callback)",
+			"Expect.That(callback).ThrowsExactly<ArgumentException>()");
+		theoryData.AddTestCase("Action callback = () => {};",
+			"Assert.Throws(typeof(ArgumentException), callback)",
+			"Expect.That(callback).ThrowsExactly(typeof(ArgumentException))");
+		theoryData.AddTestCase("Func<Task> callback = () => Task.CompletedTask;",
+			"Assert.ThrowsAsync(typeof(ArgumentException), callback)",
+			"Expect.That(callback).ThrowsExactly(typeof(ArgumentException))");
+		return theoryData;
+	}
+
+	/// <summary>
+	///     <see href="https://github.com/xunit/assert.xunit/blob/main/StringAsserts.cs" />
+	/// </summary>
+	public static TheoryData<string, string, string, bool> Strings()
+	{
+		TheoryData<string, string, string, bool> theoryData = new();
+		theoryData.AddTestCase("",
+			"Assert.Contains(\"oo\", \"foo\")",
+			"Expect.That(\"foo\").Contains(\"oo\")");
+		theoryData.AddTestCase("",
+			"Assert.DoesNotContain(\"oo\", \"foo\")",
+			"Expect.That(\"foo\").DoesNotContain(\"oo\")");
+		theoryData.AddTestCase("",
+			"Assert.StartsWith(\"fo\", \"foo\")",
+			"Expect.That(\"foo\").StartsWith(\"fo\")");
+		theoryData.AddTestCase("",
+			"Assert.EndsWith(\"oo\", \"foo\")",
+			"Expect.That(\"foo\").EndsWith(\"oo\")");
+		theoryData.AddTestCase("",
+			"Assert.Empty(\"foo\")",
+			"Expect.That(\"foo\").IsEmpty()");
+		theoryData.AddTestCase("",
+			"Assert.NotEmpty(\"foo\")",
+			"Expect.That(\"foo\").IsNotEmpty()");
+		return theoryData;
+	}
+
+	/// <summary>
+	///     <see href="https://github.com/xunit/assert.xunit/blob/main/TypeAsserts.cs" />
+	/// </summary>
+	public static TheoryData<string, string, string, bool> Types()
+	{
+		TheoryData<string, string, string, bool> theoryData = new();
+		theoryData.AddTestCase("",
+			"Assert.IsAssignableFrom<ArgumentException>(new Exception())",
+			"Expect.That(new Exception()).Is<ArgumentException>()");
+		theoryData.AddTestCase("",
+			"Assert.IsAssignableFrom(typeof(ArgumentException), new Exception())",
+			"Expect.That(new Exception()).Is(typeof(ArgumentException))");
+		theoryData.AddTestCase("",
+			"Assert.IsNotAssignableFrom<ArgumentException>(new Exception())",
+			"Expect.That(new Exception()).IsNot<ArgumentException>()");
+		theoryData.AddTestCase("",
+			"Assert.IsNotAssignableFrom(typeof(ArgumentException), new Exception())",
+			"Expect.That(new Exception()).IsNot(typeof(ArgumentException))");
+		theoryData.AddTestCase("",
+			"Assert.IsType<ArgumentException>(new Exception())",
+			"Expect.That(new Exception()).IsExactly<ArgumentException>()");
+		theoryData.AddTestCase("",
+			"Assert.IsType(typeof(ArgumentException), new Exception())",
+			"Expect.That(new Exception()).IsExactly(typeof(ArgumentException))");
+		theoryData.AddTestCase("",
+			"Assert.IsNotType<ArgumentException>(new Exception())",
+			"Expect.That(new Exception()).IsNotExactly<ArgumentException>()");
+		theoryData.AddTestCase("",
+			"Assert.IsNotType(typeof(ArgumentException), new Exception())",
+			"Expect.That(new Exception()).IsNotExactly(typeof(ArgumentException))");
+		return theoryData;
+	}
+
+	private static void AddTestCase(this TheoryData<string, string, string, bool> theoryData,
+		string arrange,
+		string actual,
+		string expected,
+		bool isAsync = false)
+		=> theoryData.Add(
+			actual,
+			expected,
+			arrange, isAsync);
+}

--- a/Tests/aweXpect.Migration.Tests/Xunit/XunitAssertionCodeFixProviderTests.cs
+++ b/Tests/aweXpect.Migration.Tests/Xunit/XunitAssertionCodeFixProviderTests.cs
@@ -7,105 +7,60 @@ namespace aweXpect.Migration.Tests.Xunit;
 public class XunitAssertionCodeFixProviderTests
 {
 	[Theory]
-	[InlineData("Assert.True(false)",
-		"Expect.That(false).IsTrue()")]
-	[InlineData("Assert.False(true)",
-		"Expect.That(true).IsFalse()")]
-	[InlineData("Assert.True(false, \"foo\")",
-		"Expect.That(false).IsTrue().Because(\"foo\")")]
-	[InlineData("Assert.False(true, \"foo\")",
-		"Expect.That(true).IsFalse().Because(\"foo\")")]
-	[InlineData("Assert.Null(new object())",
-		"Expect.That(new object()).IsNull()")]
-	[InlineData("Assert.NotNull(new object())",
-		"Expect.That(new object()).IsNotNull()")]
-	[InlineData("Assert.Equal(1, 2)",
-		"Expect.That(2).IsEqualTo(1)")]
-	[InlineData("Assert.NotEqual(1, 2)",
-		"Expect.That(2).IsNotEqualTo(1)")]
-	[InlineData("Assert.Contains(\"oo\", \"foo\")",
-		"Expect.That(\"foo\").Contains(\"oo\")")]
-	[InlineData("Assert.DoesNotContain(\"oo\", \"foo\")",
-		"Expect.That(\"foo\").DoesNotContain(\"oo\")")]
-	[InlineData("Assert.StartsWith(\"fo\", \"foo\")",
-		"Expect.That(\"foo\").StartsWith(\"fo\")")]
-	[InlineData("Assert.EndsWith(\"oo\", \"foo\")",
-		"Expect.That(\"foo\").EndsWith(\"oo\")")]
-	[InlineData("Assert.Empty(\"foo\")",
-		"Expect.That(\"foo\").IsEmpty()")]
-	[InlineData("Assert.NotEmpty(\"foo\")",
-		"Expect.That(\"foo\").IsNotEmpty()")]
-	[InlineData("Assert.Distinct([1, 2,])",
-		"Expect.That([1, 2,]).AreAllUnique()")]
-	[InlineData("Assert.Same(new ArgumentException(), new NullReferenceException())",
-		"Expect.That(new NullReferenceException()).IsSameAs(new ArgumentException())")]
-	[InlineData("Assert.NotSame(new ArgumentException(), new NullReferenceException())",
-		"Expect.That(new NullReferenceException()).IsNotSameAs(new ArgumentException())")]
-	[InlineData("Assert.IsAssignableFrom<ArgumentException>(new Exception())",
-		"Expect.That(new Exception()).Is<ArgumentException>()")]
-	[InlineData("Assert.IsAssignableFrom(typeof(ArgumentException), new Exception())",
-		"Expect.That(new Exception()).Is(typeof(ArgumentException))")]
-	[InlineData("Assert.IsNotAssignableFrom<ArgumentException>(new Exception())",
-		"Expect.That(new Exception()).IsNot<ArgumentException>()")]
-	[InlineData("Assert.IsNotAssignableFrom(typeof(ArgumentException), new Exception())",
-		"Expect.That(new Exception()).IsNot(typeof(ArgumentException))")]
-	[InlineData("Assert.IsType<ArgumentException>(new Exception())",
-		"Expect.That(new Exception()).IsExactly<ArgumentException>()")]
-	[InlineData("Assert.IsType(typeof(ArgumentException), new Exception())",
-		"Expect.That(new Exception()).IsExactly(typeof(ArgumentException))")]
-	[InlineData("Assert.IsNotType<ArgumentException>(new Exception())",
-		"Expect.That(new Exception()).IsNotExactly<ArgumentException>()")]
-	[InlineData("Assert.IsNotType(typeof(ArgumentException), new Exception())",
-		"Expect.That(new Exception()).IsNotExactly(typeof(ArgumentException))")]
-	[InlineData("Assert.Fail(\"foo\")",
-		"Fail.Test(\"foo\")")]
-	[InlineData("Assert.Skip(\"foo\")",
-		"Skip.Test(\"foo\")")]
-	[InlineData("Assert.ThrowsAny<ArgumentException>((Action)(() => {}))",
-		"Expect.That((Action)(() => {})).Throws<ArgumentException>()")]
-	[InlineData("Assert.ThrowsAnyAsync<ArgumentException>((Func<Task>)(() => Task.CompletedTask))",
-		"Expect.That((Func<Task>)(() => Task.CompletedTask)).Throws<ArgumentException>()")]
-	[InlineData("Assert.Throws<ArgumentException>((Action)(() => {}))",
-		"Expect.That((Action)(() => {})).ThrowsExactly<ArgumentException>()")]
-	[InlineData("Assert.ThrowsAsync<ArgumentException>((Func<Task>)(() => Task.CompletedTask))",
-		"Expect.That((Func<Task>)(() => Task.CompletedTask)).ThrowsExactly<ArgumentException>()")]
-	[InlineData("Assert.Throws(typeof(ArgumentException), (Action)(() => {}))",
-		"Expect.That((Action)(() => {})).ThrowsExactly(typeof(ArgumentException))")]
-	[InlineData("Assert.ThrowsAsync(typeof(ArgumentException), (Func<Task>)(() => Task.CompletedTask))",
-		"Expect.That((Func<Task>)(() => Task.CompletedTask)).ThrowsExactly(typeof(ArgumentException))")]
-	public async Task ShouldApplyCodeFix(string xunitAssertion, string aweXpectExpectation) => await Verifier
-		.VerifyCodeFixAsync(
-			$$"""
-			  using System;
-			  using System.Threading.Tasks;
-			  using aweXpect;
-			  using Xunit;
+	[MemberData(nameof(TestCases.Basic), MemberType = typeof(TestCases))]
+	public async Task ShouldApplyCodeFixForBasicTestCases(
+		string xunitAssertion,
+		string aweXpect,
+		string arrange,
+		bool isAsync) => await VerifyTestCase(xunitAssertion, aweXpect, arrange, isAsync);
 
-			  public class MyClass
-			  {
-			      [Fact]
-			      public void MyTest()
-			      {
-			          [|{{xunitAssertion}}|];
-			      }
-			  }
-			  """,
-			$$"""
-			  using System;
-			  using System.Threading.Tasks;
-			  using aweXpect;
-			  using Xunit;
+	[Theory]
+	[MemberData(nameof(TestCases.Boolean), MemberType = typeof(TestCases))]
+	public async Task ShouldApplyCodeFixForBooleanTestCases(
+		string xunitAssertion,
+		string aweXpect,
+		string arrange,
+		bool isAsync) => await VerifyTestCase(xunitAssertion, aweXpect, arrange, isAsync);
 
-			  public class MyClass
-			  {
-			      [Fact]
-			      public void MyTest()
-			      {
-			          {{aweXpectExpectation}};
-			      }
-			  }
-			  """
-		);
+	[Theory]
+	[MemberData(nameof(TestCases.Collections), MemberType = typeof(TestCases))]
+	public async Task ShouldApplyCodeFixForCollectionTestCases(
+		string xunitAssertion,
+		string aweXpect,
+		string arrange,
+		bool isAsync) => await VerifyTestCase(xunitAssertion, aweXpect, arrange, isAsync);
+
+	[Theory]
+	[MemberData(nameof(TestCases.Equality), MemberType = typeof(TestCases))]
+	public async Task ShouldApplyCodeFixForEqualityTestCases(
+		string xunitAssertion,
+		string aweXpect,
+		string arrange,
+		bool isAsync) => await VerifyTestCase(xunitAssertion, aweXpect, arrange, isAsync);
+
+	[Theory]
+	[MemberData(nameof(TestCases.Exceptions), MemberType = typeof(TestCases))]
+	public async Task ShouldApplyCodeFixForExceptionTestCases(
+		string xunitAssertion,
+		string aweXpect,
+		string arrange,
+		bool isAsync) => await VerifyTestCase(xunitAssertion, aweXpect, arrange, isAsync);
+
+	[Theory]
+	[MemberData(nameof(TestCases.Strings), MemberType = typeof(TestCases))]
+	public async Task ShouldApplyCodeFixForStringTestCases(
+		string xunitAssertion,
+		string aweXpect,
+		string arrange,
+		bool isAsync) => await VerifyTestCase(xunitAssertion, aweXpect, arrange, isAsync);
+
+	[Theory]
+	[MemberData(nameof(TestCases.Types), MemberType = typeof(TestCases))]
+	public async Task ShouldApplyCodeFixForTypeTestCases(
+		string xunitAssertion,
+		string aweXpect,
+		string arrange,
+		bool isAsync) => await VerifyTestCase(xunitAssertion, aweXpect, arrange, isAsync);
 
 	[Fact]
 	public async Task ShouldApplyCodeFixInTheory() => await Verifier
@@ -142,5 +97,50 @@ public class XunitAssertionCodeFixProviderTests
 			    }
 			}
 			"""
+		);
+
+
+	private static async Task VerifyTestCase(
+		string xunitAssertion,
+		string aweXpect,
+		string arrange,
+		bool isAsync) => await Verifier
+		.VerifyCodeFixAsync(
+			$$"""
+			  using System;
+			  using System.Collections.Generic;
+			  using System.Threading.Tasks;
+			  using aweXpect;
+			  using Xunit;
+
+			  public class MyClass
+			  {
+			      [Fact]
+			      public {{(isAsync ? "async Task" : "void")}} MyTest()
+			      {
+			          {{arrange}}
+			          
+			          {{(isAsync ? "await " : "")}}[|{{xunitAssertion}}|];
+			      }
+			  }
+			  """,
+			$$"""
+			  using System;
+			  using System.Collections.Generic;
+			  using System.Threading.Tasks;
+			  using aweXpect;
+			  using Xunit;
+
+			  public class MyClass
+			  {
+			      [Fact]
+			      public {{(isAsync ? "async Task" : "void")}} MyTest()
+			      {
+			          {{arrange}}
+			          
+			          {{(isAsync ? "await " : "")}}{{aweXpect}};
+			      }
+			  }
+			  """
 		);
 }


### PR DESCRIPTION
Support the cases when the third parameter is a number or a `TimeSpan` tolerance