### PR TITLE
feat: add migration of `OnlyContain`

### DIFF
--- a/Source/aweXpect.Migration.Analyzers.CodeFixers/FluentAssertionsCodeFixProvider.cs
+++ b/Source/aweXpect.Migration.Analyzers.CodeFixers/FluentAssertionsCodeFixProvider.cs
@@ -185,6 +185,8 @@ public class FluentAssertionsCodeFixProvider() : AssertionCodeFixProvider(Rules.
 				methods, wrapSynchronously),
 			"HaveCount" => ParseExpressionWithBecause(
 				$"Expect.That({actual}).HasCount({expected})", 1),
+			"OnlyContain" => ParseExpressionWithBecause(
+				$"Expect.That({actual}).All().Satisfy({expected})", 1),
 			"BeAssignableTo" => isGeneric
 				? ParseExpressionWithBecause(
 					$"Expect.That({actual}).Is<{genericArgs}>()", 0)

--- a/Tests/aweXpect.Migration.Tests/FluentAssertions/TestCases.cs
+++ b/Tests/aweXpect.Migration.Tests/FluentAssertions/TestCases.cs
@@ -80,6 +80,9 @@ public static class TestCases
 		theoryData.AddWithBecause("int[] subject = [1, 2,];",
 			"subject.Should().HaveCount(1, {0})",
 			"Expect.That(subject).HasCount(1)");
+		theoryData.AddWithBecause("int[] subject = [1, 2,];",
+			"subject.Should().OnlyContain(x => x > 0, {0})",
+			"Expect.That(subject).All().Satisfy(x => x > 0)");
 		return theoryData;
 	}
 


### PR DESCRIPTION
to `.All().Satisfy(predicate)`