### PR TITLE
feat: add migration of string equivalency options

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,7 +22,7 @@
 		<PackageVersion Include="xunit.v3" Version="2.0.2"/>
 		<PackageVersion Include="xunit.runner.visualstudio" Version="3.1.0"/>
 		<PackageVersion Include="coverlet.collector" Version="6.0.4"/>
-		<PackageVersion Include="FluentAssertions" Version="[7.2.0,8.0.0)"/>
+		<PackageVersion Include="FluentAssertions" Version="8.2.0"/>
 	</ItemGroup>
 	<ItemGroup>
 		<PackageVersion Include="Microsoft.CodeAnalysis" Version="4.13.0"/>

--- a/Source/aweXpect.Migration.Analyzers.CodeFixers/FluentAssertionsCodeFixProvider.cs
+++ b/Source/aweXpect.Migration.Analyzers.CodeFixers/FluentAssertionsCodeFixProvider.cs
@@ -241,7 +241,23 @@ public class FluentAssertionsCodeFixProvider() : AssertionCodeFixProvider(Rules.
 			{
 				if (secondArgument.Contains(".WithoutStrictOrdering()"))
 				{
-					expressionSuffix = ".InAnyOrder()";
+					expressionSuffix += ".InAnyOrder()";
+				}
+				if (secondArgument.Contains(".IgnoringCase()"))
+				{
+					expressionSuffix += ".IgnoringCase()";
+				}
+				if (secondArgument.Contains(".IgnoringLeadingWhitespace()"))
+				{
+					expressionSuffix += ".IgnoringLeadingWhiteSpace()";
+				}
+				if (secondArgument.Contains(".IgnoringTrailingWhitespace()"))
+				{
+					expressionSuffix += ".IgnoringTrailingWhiteSpace()";
+				}
+				if (secondArgument.Contains(".IgnoringNewlineStyle()"))
+				{
+					expressionSuffix += ".IgnoringNewlineStyle()";
 				}
 
 				becauseIndex++;

--- a/Tests/aweXpect.Migration.Tests/FluentAssertions/FluentAssertionsCodeFixProviderTests.cs
+++ b/Tests/aweXpect.Migration.Tests/FluentAssertions/FluentAssertionsCodeFixProviderTests.cs
@@ -63,6 +63,14 @@ public class FluentAssertionsCodeFixProviderTests
 		bool isAsync) => await VerifyTestCase(fluentAssertions, aweXpect, arrange, isAsync);
 
 	[Theory]
+	[MemberData(nameof(TestCases.Legacy), MemberType = typeof(TestCases))]
+	public async Task ShouldApplyCodeFixForLegacyTestCases(
+		string fluentAssertions,
+		string aweXpect,
+		string arrange,
+		bool isAsync) => await VerifyLegacyTestCase(fluentAssertions, aweXpect, arrange, isAsync);
+
+	[Theory]
 	[MemberData(nameof(TestCases.Numbers), MemberType = typeof(TestCases))]
 	public async Task ShouldApplyCodeFixForNumbersTestCases(
 		string fluentAssertions,
@@ -296,6 +304,52 @@ public class FluentAssertionsCodeFixProviderTests
 		string arrange,
 		bool isAsync) => await Verifier
 		.VerifyCodeFixAsync(
+			$$"""
+			  using System;
+			  using System.Collections.Generic;
+			  using System.Threading.Tasks;
+			  using aweXpect;
+			  using FluentAssertions;
+			  using Xunit;
+
+			  public class MyClass
+			  {
+			      [Fact]
+			      public {{(isAsync ? "async Task" : "void")}} MyTest()
+			      {
+			          {{arrange}}
+			          
+			          {{(isAsync ? "await " : "")}}[|{{fluentAssertions}}|];
+			      }
+			  }
+			  """,
+			$$"""
+			  using System;
+			  using System.Collections.Generic;
+			  using System.Threading.Tasks;
+			  using aweXpect;
+			  using FluentAssertions;
+			  using Xunit;
+
+			  public class MyClass
+			  {
+			      [Fact]
+			      public {{(isAsync ? "async Task" : "void")}} MyTest()
+			      {
+			          {{arrange}}
+			          
+			          {{(isAsync ? "await " : "")}}{{aweXpect}};
+			      }
+			  }
+			  """
+		);
+
+	private static async Task VerifyLegacyTestCase(
+		string fluentAssertions,
+		string aweXpect,
+		string arrange,
+		bool isAsync) => await Verifier
+		.VerifyLegacyCodeFixAsync(
 			$$"""
 			  using System;
 			  using System.Collections.Generic;

--- a/Tests/aweXpect.Migration.Tests/FluentAssertions/TestCases.cs
+++ b/Tests/aweXpect.Migration.Tests/FluentAssertions/TestCases.cs
@@ -195,17 +195,11 @@ public static class TestCases
 			"subject.Should().BeGreaterThan(expected, {0})",
 			"Expect.That(subject).IsGreaterThan(expected)");
 		theoryData.AddWithBecause("int subject = 1;int expected = 2;",
-			"subject.Should().BeGreaterOrEqualTo(expected, {0})",
-			"Expect.That(subject).IsGreaterThanOrEqualTo(expected)");
-		theoryData.AddWithBecause("int subject = 1;int expected = 2;",
 			"subject.Should().BeGreaterThanOrEqualTo(expected, {0})",
 			"Expect.That(subject).IsGreaterThanOrEqualTo(expected)");
 		theoryData.AddWithBecause("int subject = 1;int expected = 2;",
 			"subject.Should().BeLessThan(expected, {0})",
 			"Expect.That(subject).IsLessThan(expected)");
-		theoryData.AddWithBecause("int subject = 1;int expected = 2;",
-			"subject.Should().BeLessOrEqualTo(expected, {0})",
-			"Expect.That(subject).IsLessThanOrEqualTo(expected)");
 		theoryData.AddWithBecause("int subject = 1;int expected = 2;",
 			"subject.Should().BeLessThanOrEqualTo(expected, {0})",
 			"Expect.That(subject).IsLessThanOrEqualTo(expected)");
@@ -218,6 +212,21 @@ public static class TestCases
 		theoryData.AddWithBecause("int subject = 1;",
 			"subject.Should().BeOneOf(2, 3, 4)",
 			"Expect.That(subject).IsOneOf(2, 3, 4)");
+		return theoryData;
+	}
+
+	/// <summary>
+	///     Legacy expectations on fluentassertions 7.2.x
+	/// </summary>
+	public static TheoryData<string, string, string, bool> Legacy()
+	{
+		TheoryData<string, string, string, bool> theoryData = new();
+		theoryData.AddWithBecause("int subject = 1;int expected = 2;",
+			"subject.Should().BeLessOrEqualTo(expected, {0})",
+			"Expect.That(subject).IsLessThanOrEqualTo(expected)");
+		theoryData.AddWithBecause("int subject = 1;int expected = 2;",
+			"subject.Should().BeGreaterOrEqualTo(expected, {0})",
+			"Expect.That(subject).IsGreaterThanOrEqualTo(expected)");
 		return theoryData;
 	}
 
@@ -311,6 +320,18 @@ public static class TestCases
 		theoryData.AddWithBecause("string subject = \"foo\";string unexpected = \"bar\";",
 			"subject.Should().NotEndWith(unexpected, {0})",
 			"Expect.That(subject).DoesNotEndWith(unexpected)");
+		theoryData.AddWithBecause("string subject = \"foo\";string expected = \"bar\";",
+			"subject.Should().BeEquivalentTo(expected, o => o.IgnoringCase(), {0})",
+			"Expect.That(subject).IsEqualTo(expected).IgnoringCase()");
+		theoryData.AddWithBecause("string subject = \"foo\";string expected = \"bar\";",
+			"subject.Should().BeEquivalentTo(expected, o => o.IgnoringLeadingWhitespace(), {0})",
+			"Expect.That(subject).IsEqualTo(expected).IgnoringLeadingWhiteSpace()");
+		theoryData.AddWithBecause("string subject = \"foo\";string expected = \"bar\";",
+			"subject.Should().BeEquivalentTo(expected, o => o.IgnoringTrailingWhitespace(), {0})",
+			"Expect.That(subject).IsEqualTo(expected).IgnoringTrailingWhiteSpace()");
+		theoryData.AddWithBecause("string subject = \"foo\";string expected = \"bar\";",
+			"subject.Should().BeEquivalentTo(expected, o => o.IgnoringNewlineStyle(), {0})",
+			"Expect.That(subject).IsEqualTo(expected).IgnoringNewlineStyle()");
 		return theoryData;
 	}
 

--- a/Tests/aweXpect.Migration.Tests/Verifiers/CSharpAnalyzerVerifier`1.cs
+++ b/Tests/aweXpect.Migration.Tests/Verifiers/CSharpAnalyzerVerifier`1.cs
@@ -32,7 +32,7 @@ public static partial class CSharpAnalyzerVerifier<TAnalyzer>
 			ReferenceAssemblies = ReferenceAssemblies.Net.Net80.AddPackages(
 			[
 				new PackageIdentity("xunit.v3", "1.1.0"),
-				new PackageIdentity("FluentAssertions", "7.2.0"),
+				new PackageIdentity("FluentAssertions", "8.2.0"),
 			]),
 			TestState =
 			{

--- a/Tests/aweXpect.Migration.Tests/Verifiers/CSharpCodeFixVerifier`2.cs
+++ b/Tests/aweXpect.Migration.Tests/Verifiers/CSharpCodeFixVerifier`2.cs
@@ -37,7 +37,7 @@ public static partial class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
 			ReferenceAssemblies = ReferenceAssemblies.Net.Net80.AddPackages(
 			[
 				new PackageIdentity("xunit.v3", "1.1.0"),
-				new PackageIdentity("FluentAssertions", "7.2.0"),
+				new PackageIdentity("FluentAssertions", "8.2.0"),
 			]),
 			TestState =
 			{
@@ -67,6 +67,41 @@ public static partial class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
 	/// <inheritdoc
 	///     cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.VerifyCodeFixAsync(string, DiagnosticResult[], string)" />
 	public static async Task VerifyCodeFixAsync(
+		[StringSyntax("c#-test")] string source,
+		IEnumerable<DiagnosticResult> expected,
+		[StringSyntax("c#-test")] string fixedSource
+	)
+	{
+		Test test = new()
+		{
+			TestCode = source,
+			FixedCode = fixedSource,
+			ReferenceAssemblies = ReferenceAssemblies.Net.Net80.AddPackages(
+			[
+				new PackageIdentity("xunit.v3", "1.1.0"),
+				new PackageIdentity("FluentAssertions", "8.2.0"),
+			]),
+			TestState =
+			{
+				AdditionalReferences =
+				{
+					typeof(Expect).Assembly.Location,
+					typeof(ThatBool).Assembly.Location,
+				},
+			},
+		};
+
+		test.ExpectedDiagnostics.AddRange(expected);
+		await test.RunAsync(CancellationToken.None);
+	}
+
+	public static async Task VerifyLegacyCodeFixAsync([StringSyntax("c#-test")] string source,
+		[StringSyntax("c#-test")] string fixedSource)
+		=> await VerifyLegacyCodeFixAsync(source, DiagnosticResult.EmptyDiagnosticResults, fixedSource);
+	
+	/// <inheritdoc
+	///     cref="CodeFixVerifier{TAnalyzer, TCodeFix, TTest, TVerifier}.VerifyCodeFixAsync(string, DiagnosticResult[], string)" />
+	public static async Task VerifyLegacyCodeFixAsync(
 		[StringSyntax("c#-test")] string source,
 		IEnumerable<DiagnosticResult> expected,
 		[StringSyntax("c#-test")] string fixedSource


### PR DESCRIPTION
When specifying one of the following options, they should be migrated as well:
- `IgnoringCase`
- `IgnoringLeadingWhitespace`
- `IgnoringTrailingWhitespace`
- `IgnoringNewlineStyle`