### PR TITLE
feat: migrate `AllBeEquivalentTo`

### DIFF
--- a/Source/aweXpect.Migration.Analyzers.CodeFixers/FluentAssertionsCodeFixProvider.cs
+++ b/Source/aweXpect.Migration.Analyzers.CodeFixers/FluentAssertionsCodeFixProvider.cs
@@ -207,6 +207,8 @@ public class FluentAssertionsCodeFixProvider() : AssertionCodeFixProvider(Rules.
 					$"Expect.That({actual}).All().Are<{genericArgs}>()", 0)
 				: ParseExpressionWithBecause(
 					$"Expect.That({actual}).All().Are({expected})", 1),
+			"AllBeEquivalentTo" => await AllBeEquivalentTo(context, mainMethod.Arguments, actual, expected,
+				methods, wrapSynchronously),
 			"AllBeOfType" => isGeneric
 				? ParseExpressionWithBecause(
 					$"Expect.That({actual}).All().AreExactly<{genericArgs}>()", 0)
@@ -299,6 +301,59 @@ public class FluentAssertionsCodeFixProvider() : AssertionCodeFixProvider(Rules.
 
 		return ParseExpressionWithBecauseSupport(argumentListArguments,
 			$"Expect.That({actual}).{(negated ? "IsNotEquivalentTo" : "IsEquivalentTo")}({expected})",
+			methods, wrapSynchronously, 1);
+	}
+
+	private static async Task<ExpressionSyntax?> AllBeEquivalentTo(CodeFixContext context,
+		SeparatedSyntaxList<ArgumentSyntax> argumentListArguments,
+		ExpressionSyntax actual, ArgumentSyntax? expected, Stack<MethodDefinition> methods, bool wrapSynchronously,
+		bool negated = false)
+	{
+		SemanticModel? semanticModel = await context.Document.GetSemanticModelAsync();
+		ISymbol? actualSymbol = semanticModel.GetSymbolInfo(actual).Symbol;
+		if (semanticModel is not null && actualSymbol is not null &&
+		    GetType(actualSymbol) is { } actualSymbolType && IsStringEnumerable(actualSymbolType))
+		{
+			string expressionSuffix = "";
+			int becauseIndex = 1;
+			string? secondArgument = argumentListArguments.ElementAtOrDefault(1)?.ToString() ?? "";
+			if (!secondArgument.StartsWith("\"") || !secondArgument.EndsWith("\""))
+			{
+				if (secondArgument.Contains(".WithoutStrictOrdering()"))
+				{
+					expressionSuffix += ".InAnyOrder()";
+				}
+
+				if (secondArgument.Contains(".IgnoringCase()"))
+				{
+					expressionSuffix += ".IgnoringCase()";
+				}
+
+				if (secondArgument.Contains(".IgnoringLeadingWhitespace()"))
+				{
+					expressionSuffix += ".IgnoringLeadingWhiteSpace()";
+				}
+
+				if (secondArgument.Contains(".IgnoringTrailingWhitespace()"))
+				{
+					expressionSuffix += ".IgnoringTrailingWhiteSpace()";
+				}
+
+				if (secondArgument.Contains(".IgnoringNewlineStyle()"))
+				{
+					expressionSuffix += ".IgnoringNewlineStyle()";
+				}
+
+				becauseIndex++;
+			}
+
+			return ParseExpressionWithBecauseSupport(argumentListArguments,
+				$"Expect.That({actual}).All().{(negated ? "AreNotEqualTo" : "AreEqualTo")}({expected})" + expressionSuffix,
+				methods, wrapSynchronously, becauseIndex);
+		}
+
+		return ParseExpressionWithBecauseSupport(argumentListArguments,
+			$"Expect.That({actual}).All().{(negated ? "AreNotEquivalentTo" : "AreEquivalentTo")}({expected})",
 			methods, wrapSynchronously, 1);
 	}
 
@@ -486,6 +541,23 @@ public class FluentAssertionsCodeFixProvider() : AssertionCodeFixProvider(Rules.
 			    or "global::System.Collections.Generic.IEnumerable")
 		{
 			return true;
+		}
+
+		return typeSymbol.AllInterfaces.Any(i => i.GloballyQualified() == "global::System.Collections.IEnumerable");
+	}
+
+	private static bool IsStringEnumerable(ITypeSymbol typeSymbol)
+	{
+		if (typeSymbol is IArrayTypeSymbol arraySymbol)
+		{
+			return arraySymbol.ElementType.Name.Equals("string", StringComparison.OrdinalIgnoreCase);
+		}
+
+		if (typeSymbol is INamedTypeSymbol namedTypeSymbol
+		    && namedTypeSymbol.GloballyQualifiedNonGeneric() is "global::System.Collections.IEnumerable"
+			    or "global::System.Collections.Generic.IEnumerable")
+		{
+			return namedTypeSymbol.TypeArguments[0].Name.Equals("string", StringComparison.OrdinalIgnoreCase);
 		}
 
 		return typeSymbol.AllInterfaces.Any(i => i.GloballyQualified() == "global::System.Collections.IEnumerable");

--- a/Tests/aweXpect.Migration.Tests/FluentAssertions/FluentAssertionsCodeFixProviderTests.cs
+++ b/Tests/aweXpect.Migration.Tests/FluentAssertions/FluentAssertionsCodeFixProviderTests.cs
@@ -307,6 +307,7 @@ public class FluentAssertionsCodeFixProviderTests
 			$$"""
 			  using System;
 			  using System.Collections.Generic;
+			  using System.Linq;
 			  using System.Threading.Tasks;
 			  using aweXpect;
 			  using aweXpect.Core;
@@ -327,6 +328,7 @@ public class FluentAssertionsCodeFixProviderTests
 			$$"""
 			  using System;
 			  using System.Collections.Generic;
+			  using System.Linq;
 			  using System.Threading.Tasks;
 			  using aweXpect;
 			  using aweXpect.Core;
@@ -355,6 +357,7 @@ public class FluentAssertionsCodeFixProviderTests
 			$$"""
 			  using System;
 			  using System.Collections.Generic;
+			  using System.Linq;
 			  using System.Threading.Tasks;
 			  using aweXpect;
 			  using aweXpect.Core;
@@ -375,6 +378,7 @@ public class FluentAssertionsCodeFixProviderTests
 			$$"""
 			  using System;
 			  using System.Collections.Generic;
+			  using System.Linq;
 			  using System.Threading.Tasks;
 			  using aweXpect;
 			  using aweXpect.Core;

--- a/Tests/aweXpect.Migration.Tests/FluentAssertions/TestCases.cs
+++ b/Tests/aweXpect.Migration.Tests/FluentAssertions/TestCases.cs
@@ -89,6 +89,21 @@ public static class TestCases
 		theoryData.AddWithBecause("int[] subject = [1, 2,];",
 			"subject.Should().ContainSingle({0})",
 			"Expect.That(subject).HasSingle()");
+		theoryData.AddWithBecause("IEnumerable<int> subject = Enumerable.Range(1, 3);",
+			"subject.Should().AllBeEquivalentTo(1, {0})",
+			"Expect.That(subject).All().AreEquivalentTo(1)");
+		theoryData.AddWithBecause("string[] subject = [\"1\", \"2\",];",
+			"subject.Should().AllBeEquivalentTo(\"2\", {0})",
+			"Expect.That(subject).All().AreEqualTo(\"2\")");
+		theoryData.AddWithBecause("string[] subject = [\"1\", \"2\",];",
+			"subject.Should().AllBeEquivalentTo(\"2\", o => o.IgnoringCase(), {0})",
+			"Expect.That(subject).All().AreEqualTo(\"2\").IgnoringCase()");
+		theoryData.AddWithBecause("string[] subject = [\"1\", \"2\",];",
+			"subject.Should().AllBeEquivalentTo(\"2\", o => o.IgnoringLeadingWhitespace(), {0})",
+			"Expect.That(subject).All().AreEqualTo(\"2\").IgnoringLeadingWhiteSpace()");
+		theoryData.AddWithBecause("IEnumerable<string> subject = [\"1\", \"2\",];",
+			"subject.Should().AllBeEquivalentTo(\"2\", o => o.IgnoringTrailingWhitespace(), {0})",
+			"Expect.That(subject).All().AreEqualTo(\"2\").IgnoringTrailingWhiteSpace()");
 		theoryData.AddWithBecause("object[] subject = [];",
 			"subject.Should().AllBeAssignableTo<ArgumentException>({0})",
 			"Expect.That(subject).All().Are<ArgumentException>()");


### PR DESCRIPTION
Add support for string (`All().AreEqualTo()`) and for other types (`All().AreEquivalentTo()`).