### PR TITLE
feat: migrate `BeCloseTo`

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageVersion Include="aweXpect" Version="2.17.0"/>
+		<PackageVersion Include="aweXpect" Version="2.18.0"/>
 	</ItemGroup>
 	<ItemGroup>
 		<PackageVersion Include="Nullable" Version="1.3.1"/>

--- a/Source/aweXpect.Migration.Analyzers.CodeFixers/FluentAssertionsCodeFixProvider.cs
+++ b/Source/aweXpect.Migration.Analyzers.CodeFixers/FluentAssertionsCodeFixProvider.cs
@@ -642,6 +642,9 @@ public class FluentAssertionsCodeFixProvider() : AssertionCodeFixProvider(Rules.
 			"BeApproximately" => await ParseExpressionWithBecause(
 				$".IsEqualTo({expected}).Within({mainMethod.Arguments.ElementAtOrDefault(1)})",
 				2),
+			"BeCloseTo" => await ParseExpressionWithBecause(
+				$".IsEqualTo({expected}).Within({mainMethod.Arguments.ElementAtOrDefault(1)})",
+				2),
 			"BeAfter" => await ParseExpressionWithBecause(
 				$".IsAfter({expected})", 1),
 			"BeOnOrAfter" => await ParseExpressionWithBecause(

--- a/Source/aweXpect.Migration.Analyzers.CodeFixers/FluentAssertionsCodeFixProvider.cs
+++ b/Source/aweXpect.Migration.Analyzers.CodeFixers/FluentAssertionsCodeFixProvider.cs
@@ -642,8 +642,14 @@ public class FluentAssertionsCodeFixProvider() : AssertionCodeFixProvider(Rules.
 			"BeApproximately" => await ParseExpressionWithBecause(
 				$".IsEqualTo({expected}).Within({mainMethod.Arguments.ElementAtOrDefault(1)})",
 				2),
+			"NotBeApproximately" => await ParseExpressionWithBecause(
+				$".IsNotEqualTo({expected}).Within({mainMethod.Arguments.ElementAtOrDefault(1)})",
+				2),
 			"BeCloseTo" => await ParseExpressionWithBecause(
 				$".IsEqualTo({expected}).Within({mainMethod.Arguments.ElementAtOrDefault(1)})",
+				2),
+			"NotBeCloseTo" => await ParseExpressionWithBecause(
+				$".IsNotEqualTo({expected}).Within({mainMethod.Arguments.ElementAtOrDefault(1)})",
 				2),
 			"BeAfter" => await ParseExpressionWithBecause(
 				$".IsAfter({expected})", 1),

--- a/Tests/aweXpect.Migration.Tests/FluentAssertions/TestCases.cs
+++ b/Tests/aweXpect.Migration.Tests/FluentAssertions/TestCases.cs
@@ -336,6 +336,12 @@ public static class TestCases
 		theoryData.AddWithBecause("double subject = 1.1;double expected = 1.0;double tolerance = 0.05;",
 			"subject.Should().BeApproximately(expected, tolerance, {0})",
 			"Expect.That(subject).IsEqualTo(expected).Within(tolerance)");
+		theoryData.AddWithBecause("uint subject = 1;uint expected = 2;uint delta = 3;",
+			"subject.Should().BeCloseTo(expected, delta, {0})",
+			"Expect.That(subject).IsEqualTo(expected).Within(delta)");
+		theoryData.AddWithBecause("byte subject = 1;byte expected = 2;byte delta = 3;",
+			"subject.Should().BeCloseTo(expected, delta, {0})",
+			"Expect.That(subject).IsEqualTo(expected).Within(delta)");
 		theoryData.AddWithBecause("int subject = 1;int[] expected = [2, 3,];",
 			"subject.Should().BeOneOf(expected, {0})",
 			"Expect.That(subject).IsOneOf(expected)");

--- a/Tests/aweXpect.Migration.Tests/FluentAssertions/TestCases.cs
+++ b/Tests/aweXpect.Migration.Tests/FluentAssertions/TestCases.cs
@@ -336,12 +336,21 @@ public static class TestCases
 		theoryData.AddWithBecause("double subject = 1.1;double expected = 1.0;double tolerance = 0.05;",
 			"subject.Should().BeApproximately(expected, tolerance, {0})",
 			"Expect.That(subject).IsEqualTo(expected).Within(tolerance)");
+		theoryData.AddWithBecause("double subject = 1.1;double expected = 1.0;double tolerance = 0.05;",
+			"subject.Should().NotBeApproximately(expected, tolerance, {0})",
+			"Expect.That(subject).IsNotEqualTo(expected).Within(tolerance)");
 		theoryData.AddWithBecause("uint subject = 1;uint expected = 2;uint delta = 3;",
 			"subject.Should().BeCloseTo(expected, delta, {0})",
 			"Expect.That(subject).IsEqualTo(expected).Within(delta)");
 		theoryData.AddWithBecause("byte subject = 1;byte expected = 2;byte delta = 3;",
 			"subject.Should().BeCloseTo(expected, delta, {0})",
 			"Expect.That(subject).IsEqualTo(expected).Within(delta)");
+		theoryData.AddWithBecause("uint subject = 1;uint expected = 2;uint delta = 3;",
+			"subject.Should().NotBeCloseTo(expected, delta, {0})",
+			"Expect.That(subject).IsNotEqualTo(expected).Within(delta)");
+		theoryData.AddWithBecause("byte subject = 1;byte expected = 2;byte delta = 3;",
+			"subject.Should().NotBeCloseTo(expected, delta, {0})",
+			"Expect.That(subject).IsNotEqualTo(expected).Within(delta)");
 		theoryData.AddWithBecause("int subject = 1;int[] expected = [2, 3,];",
 			"subject.Should().BeOneOf(expected, {0})",
 			"Expect.That(subject).IsOneOf(expected)");


### PR DESCRIPTION
Migrate `Should().BeCloseTo` to `IsEqualTo(expected).Within(delta)`
Migrate `Should().NotBeCloseTo` to `IsNotEqualTo(unexpected).Within(delta)`
Migrate `Should().NotBeApproximately` to `IsNotEqualTo(unexpected).Within(delta)`

Also update aweXpect to v2.18.0