### PR TITLE
feat: migrate `Match` for objects

### DIFF
--- a/Tests/aweXpect.Migration.Tests/FluentAssertions/TestCases.cs
+++ b/Tests/aweXpect.Migration.Tests/FluentAssertions/TestCases.cs
@@ -44,6 +44,9 @@ public static class TestCases
 		theoryData.AddWithBecause("object subject = new Exception();",
 			"subject.Should().NotBeOfType(typeof(ArgumentException), {0})",
 			"Expect.That(subject).IsNotExactly(typeof(ArgumentException))");
+		theoryData.AddWithBecause("object subject = new();",
+			"subject.Should().Match(o => o.GetHashCode() > 0, {0})",
+			"Expect.That(subject).Satisfies(o => o.GetHashCode() > 0)");
 		return theoryData;
 	}
 


### PR DESCRIPTION
When using `Match` on anything except a string, it should migrate to `Satisfies`

- *fixes #56*