### PR TITLE
feat: add workflows to notify documentation site on build completion

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -170,17 +170,3 @@ jobs:
                         state: released
                     skip-label: |
                         state: released
-    
-    build-pages:
-        name: Update Pages
-        runs-on: ubuntu-latest
-        steps:
-            -   name: Trigger pages update in aweXpect Repo
-                run: |
-                    curl -L \
-                      -X POST \
-                      -H "Accept: application/vnd.github+json" \
-                      -H "Authorization: Bearer ${{ secrets.REPOSITORY_DISPATCH }}" \
-                      -H "X-GitHub-Api-Version: 2022-11-28" \
-                      https://api.github.com/repos/aweXpect/aweXpect/dispatches \
-                      -d "{\"event_type\": \"extension-documentation-updated-event\"}"

--- a/.github/workflows/notify-docs-site.yml
+++ b/.github/workflows/notify-docs-site.yml
@@ -1,0 +1,22 @@
+name: Notify Docs Site
+
+on:
+    workflow_run:
+        workflows: [ "Build" ]
+        types: [ completed ]
+        branches: [ main ]
+    workflow_dispatch:
+
+jobs:
+    dispatch:
+        if: (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+        name: Trigger Site rebuild
+        runs-on: ubuntu-latest
+        steps:
+            -   name: Dispatch extension-documentation-updated-event to Testably/Testably.Site
+                uses: peter-evans/repository-dispatch@v3
+                with:
+                    token: ${{ secrets.SITE_DISPATCH_TOKEN }}
+                    repository: Testably/Testably.Site
+                    event-type: extension-documentation-updated-event
+                    client-payload: '{"source": "${{ github.repository }}", "sha": "${{ github.event.workflow_run.head_sha || github.sha }}"}'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ All code should be covered by unit tests and comply with the coding guideline in
 
 As a framework for supporting unit testing, this project has a high standard for testing itself.  
 In order to support this, static code analysis is performed
-using [SonarCloud](https://sonarcloud.io/project/overview?id=aweXpect_aweXpect.Migration) with quality gate requiring to
+using [SonarCloud](https://sonarcloud.io/project/overview?id=Testably_aweXpect.Migration) with quality gate requiring to
 
 - solve all issues reported by SonarCloud
 - have a code coverage of > 90%

--- a/Pipeline/Build.CodeAnalysis.cs
+++ b/Pipeline/Build.CodeAnalysis.cs
@@ -16,8 +16,8 @@ partial class Build
 		.Executes(() =>
 		{
 			SonarScannerTasks.SonarScannerBegin(s => s
-				.SetOrganization("awexpect")
-				.SetProjectKey("aweXpect_aweXpect.Migration")
+				.SetOrganization("testably")
+				.SetProjectKey("Testably_aweXpect.Migration")
 				.AddVSTestReports(TestResultsDirectory / "*.trx")
 				.AddOpenCoverPaths(TestResultsDirectory / "reports" / "OpenCover.xml")
 				.SetPullRequestOrBranchName(GitHubActions, GitVersion)

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![Nuget](https://img.shields.io/nuget/v/aweXpect.Migration)](https://www.nuget.org/packages/aweXpect.Migration)
 [![Build](https://github.com/aweXpect/aweXpect.Migration/actions/workflows/build.yml/badge.svg)](https://github.com/aweXpect/aweXpect.Migration/actions/workflows/build.yml)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=aweXpect_aweXpect.Migration&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=aweXpect_aweXpect.Migration)
-[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=aweXpect_aweXpect.Migration&metric=coverage)](https://sonarcloud.io/summary/overall?id=aweXpect_aweXpect.Migration)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=Testably_aweXpect.Migration&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=Testably_aweXpect.Migration)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=Testably_aweXpect.Migration&metric=coverage)](https://sonarcloud.io/summary/overall?id=Testably_aweXpect.Migration)
 
 We added support to migrate from other testing frameworks.
 


### PR DESCRIPTION
This pull request updates the workflow for notifying the documentation site after a successful build. The main change is the replacement of the previous method for triggering a documentation site update with a new, more robust workflow. The new workflow uses the `repository-dispatch` action to notify the `Testably/Testably.Site` repository when the build completes successfully on the `main` branch.