### PR TITLE
chore: update aweXpect references and improve diagnostic rules documentation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ jobs:
     unit-tests:
         name: "Unit tests"
         strategy:
+            fail-fast: false
             matrix:
                 os: [ ubuntu-latest, windows-latest, macos-latest ]
         runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ jobs:
     unit-tests:
         name: "Unit tests"
         strategy:
+            fail-fast: false
             matrix:
                 os: [ ubuntu-latest, windows-latest, macos-latest ]
         runs-on: ${{ matrix.os }}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -29,9 +29,9 @@
 		<PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
 		<PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.11.0" />
 		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
-		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.2" />
-		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.2" />
-		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing" Version="1.1.2" />
+		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.3" />
+		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.3" />
+		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing" Version="1.1.3" />
 		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0" />
 		<PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.11.0" />
 	</ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageVersion Include="aweXpect" Version="2.26.0"/>
+		<PackageVersion Include="aweXpect" Version="2.31.0"/>
 	</ItemGroup>
 	<ItemGroup>
 		<PackageVersion Include="Nullable" Version="1.3.1"/>

--- a/Source/aweXpect.Migration.Analyzers/Rules.cs
+++ b/Source/aweXpect.Migration.Analyzers/Rules.cs
@@ -2,13 +2,22 @@
 
 namespace aweXpect.Migration.Analyzers;
 
-internal static class Rules
+/// <summary>
+///     Diagnostic rules reported by the aweXpect migration analyzers.
+/// </summary>
+public static class Rules
 {
 	private const string UsageCategory = "Usage";
 
+	/// <summary>
+	///     Rule <c>aweXpectM002</c>: a FluentAssertions assertion was detected and can be migrated to aweXpect.
+	/// </summary>
 	public static readonly DiagnosticDescriptor FluentAssertionsRule =
 		CreateDescriptor("aweXpectM002", UsageCategory, DiagnosticSeverity.Warning);
 
+	/// <summary>
+	///     Rule <c>aweXpectM003</c>: an xUnit assertion was detected and can be migrated to aweXpect.
+	/// </summary>
 	public static readonly DiagnosticDescriptor XunitAssertionRule =
 		CreateDescriptor("aweXpectM003", UsageCategory, DiagnosticSeverity.Warning);
 

--- a/Source/aweXpect.Migration.Analyzers/aweXpect.Migration.Analyzers.csproj
+++ b/Source/aweXpect.Migration.Analyzers/aweXpect.Migration.Analyzers.csproj
@@ -22,7 +22,6 @@
 
 	<ItemGroup>
 		<InternalsVisibleTo Include="aweXpect.Migration.Analyzers.CodeFixers" PublicKey="$(PublicKey)"/>
-		<InternalsVisibleTo Include="aweXpect.Migration.Tests" PublicKey="$(PublicKey)"/>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Tests/aweXpect.Migration.Tests/Verifiers/CSharpAnalyzerVerifier`1.cs
+++ b/Tests/aweXpect.Migration.Tests/Verifiers/CSharpAnalyzerVerifier`1.cs
@@ -29,7 +29,7 @@ public static partial class CSharpAnalyzerVerifier<TAnalyzer>
 		Test test = new()
 		{
 			TestCode = source,
-			ReferenceAssemblies = ReferenceAssemblies.Net.Net80.AddPackages(
+			ReferenceAssemblies = ReferenceAssemblies.Net.Net100.AddPackages(
 			[
 				new PackageIdentity("xunit.v3", "1.1.0"),
 				new PackageIdentity("FluentAssertions", "8.2.0"),

--- a/Tests/aweXpect.Migration.Tests/Verifiers/CSharpCodeFixVerifier`2.cs
+++ b/Tests/aweXpect.Migration.Tests/Verifiers/CSharpCodeFixVerifier`2.cs
@@ -34,7 +34,7 @@ public static partial class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
 		{
 			TestCode = source,
 			CodeActionValidationMode = CodeActionValidationMode.SemanticStructure,
-			ReferenceAssemblies = ReferenceAssemblies.Net.Net80.AddPackages(
+			ReferenceAssemblies = ReferenceAssemblies.Net.Net100.AddPackages(
 			[
 				new PackageIdentity("xunit.v3", "1.1.0"),
 				new PackageIdentity("FluentAssertions", "8.2.0"),
@@ -76,7 +76,7 @@ public static partial class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
 		{
 			TestCode = source,
 			FixedCode = fixedSource,
-			ReferenceAssemblies = ReferenceAssemblies.Net.Net80.AddPackages(
+			ReferenceAssemblies = ReferenceAssemblies.Net.Net100.AddPackages(
 			[
 				new PackageIdentity("xunit.v3", "1.1.0"),
 				new PackageIdentity("FluentAssertions", "8.2.0"),
@@ -111,7 +111,7 @@ public static partial class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
 		{
 			TestCode = source,
 			FixedCode = fixedSource,
-			ReferenceAssemblies = ReferenceAssemblies.Net.Net80.AddPackages(
+			ReferenceAssemblies = ReferenceAssemblies.Net.Net100.AddPackages(
 			[
 				new PackageIdentity("xunit.v3", "1.1.0"),
 				new PackageIdentity("FluentAssertions", "7.2.0"),


### PR DESCRIPTION
This pull request updates dependencies and makes some code quality and accessibility improvements to the `aweXpect.Migration.Analyzers` project. The most important changes are:

Dependency updates:

* Upgraded the `aweXpect` package version from `2.26.0` to `2.31.0` in `Directory.Packages.props` to ensure the latest features and fixes are used.

Code accessibility and documentation:

* Changed the `Rules` class in `Rules.cs` from `internal` to `public` and added XML documentation comments to improve code clarity and allow access from other assemblies.

Project structure:

* Removed `aweXpect.Migration.Tests` from the `InternalsVisibleTo` list in the project file, tightening assembly access and potentially improving encapsulation.